### PR TITLE
chore: add Husky pre-commit hook for auto-formatting

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+pnpm format

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
 		"start": "next start",
 		"lint": "eslint",
 		"format": "biome format --write",
-		"convex:dev": "pnpx convex dev"
+		"convex:dev": "pnpx convex dev",
+		"prepare": "husky"
 	},
 	"dependencies": {
 		"@clerk/nextjs": "^6.36.7",
@@ -48,6 +49,7 @@
 		"@types/react-dom": "^19",
 		"eslint": "^9",
 		"eslint-config-next": "16.1.1",
+		"husky": "^9.1.7",
 		"tailwindcss": "^4",
 		"tailwindcss-animate": "^1.0.7",
 		"tw-animate-css": "^1.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       eslint-config-next:
         specifier: 16.1.1
         version: 16.1.1(@typescript-eslint/parser@8.52.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.8.3)
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       tailwindcss:
         specifier: ^4
         version: 4.1.18
@@ -2009,6 +2012,11 @@ packages:
 
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -4777,6 +4785,8 @@ snapshots:
   hermes-parser@0.25.1:
     dependencies:
       hermes-estree: 0.25.1
+
+  husky@9.1.7: {}
 
   ignore@5.3.2: {}
 


### PR DESCRIPTION
## Summary

Adds Husky pre-commit hook that runs `pnpm format` automatically before each commit.

## How it works

1. Developer runs `pnpm install` → Husky activates
2. Developer runs `git commit` → Hook runs `pnpm format` first
3. Files are formatted → Commit proceeds

## Benefits

- No more formatting conflicts in PRs
- Impossible to forget running format
- Works for all team members automatically

🤖 Generated with [Claude Code](https://claude.ai/code)