### PR TITLE
feat(i18n): persist locale preference in Convex DB

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -12,6 +12,7 @@ import { PostHogIdentify } from "@/components/posthog-identify";
 import { Toaster } from "@/components/ui/sonner";
 import { ProfileProvider } from "@/components/profile-provider";
 import { ChatWidget } from "@/components/chat-widget";
+import { LocaleSync } from "@/components/locale-sync";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -87,6 +88,7 @@ export default async function RootLayout({
             <ConvexClientProvider>
               <PostHogIdentify />
               <ProfileProvider>
+                <LocaleSync />
                 <AppHeader />
                 <div className="pb-20 md:pb-0">{children}</div>
                 <MobileTabBar />

--- a/components/language-switcher.tsx
+++ b/components/language-switcher.tsx
@@ -9,14 +9,24 @@ import {
   SelectTrigger,
 } from "@/components/ui/select";
 import { Globe } from "lucide-react";
+import { useMutation } from "convex/react";
+import { useConvexAuth } from "convex/react";
+import { api } from "@/convex/_generated/api";
 
 export function LanguageSwitcher() {
   const locale = useLocale();
   const router = useRouter();
   const pathname = usePathname();
+  const { isAuthenticated } = useConvexAuth();
+  const updateLocale = useMutation(api.users.updateLocale);
 
   function onSelectChange(nextLocale: string) {
     router.replace(pathname, { locale: nextLocale });
+    if (isAuthenticated) {
+      updateLocale({
+        locale: nextLocale as "en" | "vi" | "ru",
+      }).catch(console.error);
+    }
   }
 
   return (

--- a/components/locale-sync.tsx
+++ b/components/locale-sync.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect } from "react";
+import { useQuery } from "convex/react";
+import { useLocale } from "next-intl";
+import { usePathname, useRouter } from "@/i18n/routing";
+import { api } from "@/convex/_generated/api";
+
+/**
+ * Restores the user's stored locale preference on login or cross-device access.
+ * Renders nothing; placed inside a SignedIn boundary in the layout.
+ */
+export function LocaleSync() {
+  const profile = useQuery(api.users.getMyProfile);
+  const locale = useLocale();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (profile?.locale && profile.locale !== locale) {
+      router.replace(pathname, { locale: profile.locale });
+    }
+  }, [profile?.locale, locale, pathname, router]);
+
+  return null;
+}

--- a/convex/emails.ts
+++ b/convex/emails.ts
@@ -66,6 +66,7 @@ export const buildDigestPayloads = internalQuery({
     const results: Array<{
       clerkId: string;
       email: string;
+      locale: "en" | "vi" | "ru";
       data: {
         userName: string;
         mode: "daily" | "weekly";
@@ -125,6 +126,7 @@ export const buildDigestPayloads = internalQuery({
       results.push({
         clerkId,
         email: userRecord.email,
+        locale: userRecord.locale ?? "en",
         data: {
           userName: userRecord.name ?? "there",
           mode: args.mode,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -175,6 +175,9 @@ export default defineSchema({
     digestFrequency: v.optional(
       v.union(v.literal("daily"), v.literal("weekly"), v.literal("off")),
     ),
+    locale: v.optional(
+      v.union(v.literal("en"), v.literal("vi"), v.literal("ru")),
+    ),
     createdAt: v.number(),
     updatedAt: v.number(),
   }).index("by_clerk_id", ["clerkId"]),

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -7,7 +7,17 @@ import {
 } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { v } from "convex/values";
+import type { WithoutSystemFields } from "convex/server";
+import type { Doc } from "./_generated/dataModel";
 import { vCloudinaryRef } from "./mediaTypes";
+
+type UserFields = WithoutSystemFields<Doc<"users">>;
+type NullableFields<T> = { [K in keyof T]: T[K] | null };
+type MyProfile = NullableFields<UserFields> & {
+  avatarUrl: string | null;
+  hasProfile: boolean;
+  clerkData: { name: string | null; email: string | null; avatarUrl: string | null };
+};
 
 // Contact info validator
 const contactsValidator = v.optional(
@@ -24,13 +34,12 @@ const contactsValidator = v.optional(
  */
 export const getMyProfile = query({
   args: {},
-  handler: async (ctx) => {
+  handler: async (ctx): Promise<MyProfile | null> => {
     const identity = await ctx.auth.getUserIdentity();
     if (!identity) {
       return null;
     }
 
-    // Clerk data for comparison/reset
     const clerkData = {
       name: identity.name || identity.nickname || null,
       email: identity.email || null,
@@ -43,34 +52,48 @@ export const getMyProfile = query({
       .first();
 
     if (!profile) {
-      // Return basic info from Clerk if no profile exists yet
       return {
         clerkId: identity.subject,
-        name: clerkData.name,
         email: clerkData.email,
+        name: clerkData.name,
+        avatarStorageId: null,
+        avatarCloudinary: null,
         avatarUrl: clerkData.avatarUrl,
         address: null,
+        ward: null,
         bio: null,
         contacts: null,
-        digestFrequency: null as "daily" | "weekly" | "off" | null,
+        digestFrequency: null,
+        locale: null,
+        createdAt: null,
+        updatedAt: null,
         hasProfile: false,
         clerkData,
       };
     }
 
-    // Get avatar URL if exists
     let avatarUrl: string | null = null;
     if (profile.avatarCloudinary) {
       avatarUrl = profile.avatarCloudinary.secureUrl;
     } else if (identity.pictureUrl) {
-      // Fallback to Clerk avatar
       avatarUrl = identity.pictureUrl;
     }
 
     return {
-      ...profile,
+      clerkId: profile.clerkId,
       email: clerkData.email,
+      name: profile.name ?? null,
+      avatarStorageId: profile.avatarStorageId ?? null,
+      avatarCloudinary: profile.avatarCloudinary ?? null,
       avatarUrl,
+      address: profile.address ?? null,
+      ward: profile.ward ?? null,
+      bio: profile.bio ?? null,
+      contacts: profile.contacts ?? null,
+      digestFrequency: profile.digestFrequency ?? null,
+      locale: profile.locale ?? null,
+      createdAt: profile.createdAt,
+      updatedAt: profile.updatedAt,
       hasProfile: true,
       clerkData,
     };

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -217,6 +217,10 @@ export const getProfileWithContacts = query({
 /**
  * Create or update user profile
  */
+const localeValidator = v.optional(
+  v.union(v.literal("en"), v.literal("vi"), v.literal("ru")),
+);
+
 export const updateProfile = mutation({
   args: {
     name: v.optional(v.string()),
@@ -228,6 +232,7 @@ export const updateProfile = mutation({
     digestFrequency: v.optional(
       v.union(v.literal("daily"), v.literal("weekly"), v.literal("off")),
     ),
+    locale: localeValidator,
   },
   handler: async (ctx, args) => {
     const identity = await ctx.auth.getUserIdentity();
@@ -275,6 +280,37 @@ export const updateProfile = mutation({
     });
 
     return profileId;
+  },
+});
+
+/**
+ * Update only the locale preference (called by LanguageSwitcher)
+ */
+export const updateLocale = mutation({
+  args: {
+    locale: v.union(v.literal("en"), v.literal("vi"), v.literal("ru")),
+  },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) return;
+
+    const existing = await ctx.db
+      .query("users")
+      .withIndex("by_clerk_id", (q) => q.eq("clerkId", identity.subject))
+      .first();
+
+    const now = Date.now();
+
+    if (existing) {
+      await ctx.db.patch(existing._id, { locale: args.locale, updatedAt: now });
+    } else {
+      await ctx.db.insert("users", {
+        clerkId: identity.subject,
+        locale: args.locale,
+        createdAt: now,
+        updatedAt: now,
+      });
+    }
   },
 });
 
@@ -407,6 +443,20 @@ export const getUserHistory = query({
         totalBorrowed: borrowingHistory.length,
       },
     };
+  },
+});
+
+/**
+ * Internal: get a user's stored locale preference (falls back to "en")
+ */
+export const getLocale = internalQuery({
+  args: { clerkId: v.string() },
+  handler: async (ctx, args) => {
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_clerk_id", (q) => q.eq("clerkId", args.clerkId))
+      .first();
+    return user?.locale ?? "en";
   },
 });
 


### PR DESCRIPTION
- add `locale` field to users schema (en/vi/ru)
- add `updateLocale` mutation called by LanguageSwitcher
- add `LocaleSync` component to restore locale on login