### PR TITLE
feat(i18n): translate outbound emails into user's locale

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -384,6 +384,65 @@ git commit --amend --no-edit
 - Только owner может approve/reject claims
 - Только claimer может отменить свою заявку
 
+## Email Templates (i18n)
+
+All outbound emails support `en`, `vi`, and `ru` via a Convex-side dictionary — `next-intl` is unavailable in Convex Node actions.
+
+### Where strings live
+
+All translatable copy lives in `convex/emailTemplates/i18n.ts`. Each key appears once per locale:
+
+```typescript
+const emailStrings: Record<Locale, Record<string, string>> = {
+  en: { "welcome.subject": "Welcome to Sharity!", ... },
+  vi: { "welcome.subject": "Chào mừng bạn đến với Sharity!", ... },
+  ru: { "welcome.subject": "Добро пожаловать в Sharity!", ... },
+};
+```
+
+### Adding a new email
+
+1. Add all string keys to `emailStrings` in `i18n.ts` for all 3 locales.
+2. Create a template in `convex/emailTemplates/yourEmail.tsx`. The template **must** accept `locale: Locale` and pass it to `SharityEmail`.
+3. Use `t(locale, "key", { param: value })` for all copy; `formatDateLocalized(ts, locale)` / `formatWindowLocalized(start, end, locale)` for dates.
+4. Add `locale: localeValidator` arg to the action in `emailSend.ts`; use `t(locale, "key")` for the subject.
+5. At the scheduler call site, pass `locale: user.profile.locale`.
+
+### Pattern example
+
+```typescript
+// emailTemplates/myEmail.tsx
+export function MyEmail({ name, locale }: { name: string; locale: Locale }) {
+  return (
+    <SharityEmail preview={t(locale, "myEmail.preview", { name })} locale={locale}>
+      <Text>{t(locale, "myEmail.heading", { name })}</Text>
+    </SharityEmail>
+  );
+}
+
+// emailSend.ts action
+export const sendMyEmail = internalAction({
+  args: { email: v.string(), name: v.string(), locale: localeValidator },
+  handler: async (ctx, args) => {
+    const locale = resolveLocale(args.locale);
+    await sendMail(ctx, args.email, t(locale, "myEmail.subject"),
+      React.createElement(MyEmail, { name: args.name, locale }));
+  },
+});
+
+// Call site in items.ts
+await ctx.scheduler.runAfter(0, internal.emailSend.sendMyEmail, {
+  email: user.email,
+  name: user.name,
+  locale: user.profile.locale,   // ← always pass locale from user record
+});
+```
+
+### Rules
+- `SharityEmail` **requires** `locale` — TypeScript will catch new templates that omit it.
+- Missing keys fall back to English automatically.
+- For plurals in Russian use `t()` with `"singular|few|many"` format + `pluralize()`.
+
 ## Leaflet Maps (react-leaflet)
 
 ### ВАЖНО: Tailwind CSS 4 ломает Leaflet tiles!

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -14,6 +14,7 @@ import type * as crons from "../crons.js";
 import type * as emailSend from "../emailSend.js";
 import type * as emailTemplates__shared from "../emailTemplates/_shared.js";
 import type * as emailTemplates_dailyDigest from "../emailTemplates/dailyDigest.js";
+import type * as emailTemplates_i18n from "../emailTemplates/i18n.js";
 import type * as emailTemplates_index from "../emailTemplates/index.js";
 import type * as emailTemplates_itemAvailable from "../emailTemplates/itemAvailable.js";
 import type * as emailTemplates_leaseApproved from "../emailTemplates/leaseApproved.js";
@@ -49,6 +50,7 @@ declare const fullApi: ApiFromModules<{
   emailSend: typeof emailSend;
   "emailTemplates/_shared": typeof emailTemplates__shared;
   "emailTemplates/dailyDigest": typeof emailTemplates_dailyDigest;
+  "emailTemplates/i18n": typeof emailTemplates_i18n;
   "emailTemplates/index": typeof emailTemplates_index;
   "emailTemplates/itemAvailable": typeof emailTemplates_itemAvailable;
   "emailTemplates/leaseApproved": typeof emailTemplates_leaseApproved;

--- a/convex/emailSend.ts
+++ b/convex/emailSend.ts
@@ -5,416 +5,458 @@ import { v } from "convex/values";
 import { internalAction } from "./_generated/server";
 import { internal } from "./_generated/api";
 import {
-  WelcomeEmail,
-  LeaseApprovedEmail,
-  MeetupConfirmedEmail,
-  DailyDigestEmail,
-  OverdueAlertEmail,
-  NewRequestEmail,
-  RequestRejectedEmail,
-  MeetupProposedEmail,
-  ItemAvailableEmail,
+	WelcomeEmail,
+	LeaseApprovedEmail,
+	MeetupConfirmedEmail,
+	DailyDigestEmail,
+	OverdueAlertEmail,
+	NewRequestEmail,
+	RequestRejectedEmail,
+	MeetupProposedEmail,
+	ItemAvailableEmail,
 } from "./emailTemplates/index";
 import type {
-  LeaseApprovedData,
-  MeetupConfirmedData,
-  DigestData,
-  OverdueAlertData,
-  NewRequestData,
-  RequestRejectedData,
-  MeetupProposedData,
-  ItemAvailableData,
+	LeaseApprovedData,
+	MeetupConfirmedData,
+	DigestData,
+	OverdueAlertData,
+	NewRequestData,
+	RequestRejectedData,
+	MeetupProposedData,
+	ItemAvailableData,
 } from "./emailTemplates/index";
 import * as React from "react";
 import { resend, FROM } from "./resendClient";
 import type { ActionCtx } from "./_generated/server";
+import { t } from "./emailTemplates/i18n";
+import type { Locale } from "./emailTemplates/i18n";
+
+// ─── Locale validator ─────────────────────────────────────────────────────────
+
+const localeValidator = v.optional(
+	v.union(v.literal("en"), v.literal("vi"), v.literal("ru")),
+);
+
+function resolveLocale(locale: string | undefined): Locale {
+	return (locale as Locale | undefined) ?? "en";
+}
 
 // ─── Internal helper ──────────────────────────────────────────────────────────
 
 async function sendMail(
-  ctx: ActionCtx,
-  to: string,
-  subject: string,
-  component: React.ReactElement,
+	ctx: ActionCtx,
+	to: string,
+	subject: string,
+	component: React.ReactElement,
 ): Promise<void> {
-  const html = await render(component);
-  const text = await render(component, { plainText: true });
-  await resend.sendEmail(ctx, { from: FROM, to: [to], subject, html, text });
+	const html = await render(component);
+	const text = await render(component, { plainText: true });
+	await resend.sendEmail(ctx, { from: FROM, to: [to], subject, html, text });
 }
 
 // ─── 1. Welcome ───────────────────────────────────────────────────────────────
 
 export const sendWelcome = internalAction({
-  args: {
-    clerkId: v.string(),
-    email: v.string(),
-    name: v.string(),
-  },
-  handler: async (ctx, args) => {
-    const key = `welcome/${args.clerkId}`;
-    const alreadySent = await ctx.runQuery(internal.emails.hasEmailBeenSent, {
-      key,
-    });
-    if (alreadySent) return;
+	args: {
+		clerkId: v.string(),
+		email: v.string(),
+		name: v.string(),
+		locale: localeValidator,
+	},
+	handler: async (ctx, args) => {
+		const key = `welcome/${args.clerkId}`;
+		const alreadySent = await ctx.runQuery(internal.emails.hasEmailBeenSent, {
+			key,
+		});
+		if (alreadySent) return;
 
-    await sendMail(
-      ctx,
-      args.email,
-      "Welcome to Sharity!",
-      React.createElement(WelcomeEmail, { name: args.name }),
-    );
-    await ctx.runMutation(internal.emails.logEmail, { key });
-  },
+		const locale = resolveLocale(args.locale);
+		await sendMail(
+			ctx,
+			args.email,
+			t(locale, "welcome.subject"),
+			React.createElement(WelcomeEmail, { name: args.name, locale }),
+		);
+		await ctx.runMutation(internal.emails.logEmail, { key });
+	},
 });
 
 // ─── 2. Lease Approved ────────────────────────────────────────────────────────
 
 export const sendLeaseApproved = internalAction({
-  args: {
-    claimId: v.id("claims"),
-    borrowerEmail: v.string(),
-    data: v.object({
-      borrowerName: v.string(),
-      itemName: v.string(),
-      startDate: v.number(),
-      endDate: v.number(),
-      claimId: v.string(),
-      itemId: v.string(),
-    }),
-  },
-  handler: async (ctx, args) => {
-    const key = `lease-approved/${args.claimId}`;
-    const alreadySent = await ctx.runQuery(internal.emails.hasEmailBeenSent, {
-      key,
-    });
-    if (alreadySent) return;
+	args: {
+		claimId: v.id("claims"),
+		borrowerEmail: v.string(),
+		locale: localeValidator,
+		data: v.object({
+			borrowerName: v.string(),
+			itemName: v.string(),
+			startDate: v.number(),
+			endDate: v.number(),
+			claimId: v.string(),
+			itemId: v.string(),
+		}),
+	},
+	handler: async (ctx, args) => {
+		const key = `lease-approved/${args.claimId}`;
+		const alreadySent = await ctx.runQuery(internal.emails.hasEmailBeenSent, {
+			key,
+		});
+		if (alreadySent) return;
 
-    const data: LeaseApprovedData = args.data;
-    await sendMail(
-      ctx,
-      args.borrowerEmail,
-      `Your request for "${data.itemName}" was approved`,
-      React.createElement(LeaseApprovedEmail, data),
-    );
-    await ctx.runMutation(internal.emails.logEmail, { key });
-  },
+		const locale = resolveLocale(args.locale);
+		const data: LeaseApprovedData = { ...args.data, locale };
+		await sendMail(
+			ctx,
+			args.borrowerEmail,
+			t(locale, "leaseApproved.subject", { itemName: data.itemName }),
+			React.createElement(LeaseApprovedEmail, data),
+		);
+		await ctx.runMutation(internal.emails.logEmail, { key });
+	},
 });
 
 // ─── 3. Meetup Confirmed ─────────────────────────────────────────────────────
 
 export const sendMeetupConfirmed = internalAction({
-  args: {
-    claimId: v.id("claims"),
-    meetupType: v.union(v.literal("pickup"), v.literal("return")),
-    recipient1Email: v.string(),
-    recipient2Email: v.string(),
-    data1: v.object({
-      recipientName: v.string(),
-      counterpartyName: v.string(),
-      counterpartyContacts: v.object({
-        telegram: v.optional(v.string()),
-        whatsapp: v.optional(v.string()),
-        facebook: v.optional(v.string()),
-        phone: v.optional(v.string()),
-      }),
-      itemName: v.string(),
-      windowStartAt: v.number(),
-      windowEndAt: v.number(),
-      itemId: v.string(),
-      meetupType: v.union(v.literal("pickup"), v.literal("return")),
-    }),
-    data2: v.object({
-      recipientName: v.string(),
-      counterpartyName: v.string(),
-      counterpartyContacts: v.object({
-        telegram: v.optional(v.string()),
-        whatsapp: v.optional(v.string()),
-        facebook: v.optional(v.string()),
-        phone: v.optional(v.string()),
-      }),
-      itemName: v.string(),
-      windowStartAt: v.number(),
-      windowEndAt: v.number(),
-      itemId: v.string(),
-      meetupType: v.union(v.literal("pickup"), v.literal("return")),
-    }),
-  },
-  handler: async (ctx, args) => {
-    const key1 = `meetup-${args.meetupType}-borrower/${args.claimId}`;
-    const key2 = `meetup-${args.meetupType}-owner/${args.claimId}`;
+	args: {
+		claimId: v.id("claims"),
+		meetupType: v.union(v.literal("pickup"), v.literal("return")),
+		recipient1Email: v.string(),
+		recipient2Email: v.string(),
+		locale1: localeValidator,
+		locale2: localeValidator,
+		data1: v.object({
+			recipientName: v.string(),
+			counterpartyName: v.string(),
+			counterpartyContacts: v.object({
+				telegram: v.optional(v.string()),
+				whatsapp: v.optional(v.string()),
+				facebook: v.optional(v.string()),
+				phone: v.optional(v.string()),
+			}),
+			itemName: v.string(),
+			windowStartAt: v.number(),
+			windowEndAt: v.number(),
+			itemId: v.string(),
+			meetupType: v.union(v.literal("pickup"), v.literal("return")),
+		}),
+		data2: v.object({
+			recipientName: v.string(),
+			counterpartyName: v.string(),
+			counterpartyContacts: v.object({
+				telegram: v.optional(v.string()),
+				whatsapp: v.optional(v.string()),
+				facebook: v.optional(v.string()),
+				phone: v.optional(v.string()),
+			}),
+			itemName: v.string(),
+			windowStartAt: v.number(),
+			windowEndAt: v.number(),
+			itemId: v.string(),
+			meetupType: v.union(v.literal("pickup"), v.literal("return")),
+		}),
+	},
+	handler: async (ctx, args) => {
+		const key1 = `meetup-${args.meetupType}-borrower/${args.claimId}`;
+		const key2 = `meetup-${args.meetupType}-owner/${args.claimId}`;
 
-    const [sent1, sent2] = await Promise.all([
-      ctx.runQuery(internal.emails.hasEmailBeenSent, { key: key1 }),
-      ctx.runQuery(internal.emails.hasEmailBeenSent, { key: key2 }),
-    ]);
+		const [sent1, sent2] = await Promise.all([
+			ctx.runQuery(internal.emails.hasEmailBeenSent, { key: key1 }),
+			ctx.runQuery(internal.emails.hasEmailBeenSent, { key: key2 }),
+		]);
 
-    const data1 = args.data1 as MeetupConfirmedData;
-    const data2 = args.data2 as MeetupConfirmedData;
-    const subject = `Meetup confirmed for "${data1.itemName}"`;
+		const locale1 = resolveLocale(args.locale1);
+		const locale2 = resolveLocale(args.locale2);
+		const data1: MeetupConfirmedData = { ...args.data1, locale: locale1 };
+		const data2: MeetupConfirmedData = { ...args.data2, locale: locale2 };
 
-    await Promise.all([
-      !sent1
-        ? sendMail(
-            ctx,
-            args.recipient1Email,
-            subject,
-            React.createElement(MeetupConfirmedEmail, data1),
-          ).then(() => ctx.runMutation(internal.emails.logEmail, { key: key1 }))
-        : Promise.resolve(),
-      !sent2
-        ? sendMail(
-            ctx,
-            args.recipient2Email,
-            subject,
-            React.createElement(MeetupConfirmedEmail, data2),
-          ).then(() => ctx.runMutation(internal.emails.logEmail, { key: key2 }))
-        : Promise.resolve(),
-    ]);
-  },
+		await Promise.all([
+			!sent1
+				? sendMail(
+						ctx,
+						args.recipient1Email,
+						t(locale1, "meetupConfirmed.subject", { itemName: data1.itemName }),
+						React.createElement(MeetupConfirmedEmail, data1),
+					).then(() =>
+						ctx.runMutation(internal.emails.logEmail, { key: key1 }),
+					)
+				: Promise.resolve(),
+			!sent2
+				? sendMail(
+						ctx,
+						args.recipient2Email,
+						t(locale2, "meetupConfirmed.subject", { itemName: data2.itemName }),
+						React.createElement(MeetupConfirmedEmail, data2),
+					).then(() =>
+						ctx.runMutation(internal.emails.logEmail, { key: key2 }),
+					)
+				: Promise.resolve(),
+		]);
+	},
 });
 
-// ─── 4. Daily Digest ─────────────────────────────────────────────────────────
+// ─── 4. Daily / Weekly Digest ─────────────────────────────────────────────────
 
 async function sendDigests(
-  ctx: ActionCtx,
-  mode: "daily" | "weekly",
+	ctx: ActionCtx,
+	mode: "daily" | "weekly",
 ): Promise<void> {
-  const usersWithActivity: Array<{
-    clerkId: string;
-    email: string;
-    data: DigestData;
-  }> = await ctx.runQuery(internal.emails.buildDigestPayloads, { mode });
+	const usersWithActivity: Array<{
+		clerkId: string;
+		email: string;
+		locale: Locale;
+		data: Omit<DigestData, "locale">;
+	}> = await ctx.runQuery(internal.emails.buildDigestPayloads, { mode });
 
-  for (const user of usersWithActivity) {
-    const dateKey = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
-    const key = `digest-${mode}/${user.clerkId}/${dateKey}`;
-    const alreadySent = await ctx.runQuery(internal.emails.hasEmailBeenSent, {
-      key,
-    });
-    if (alreadySent) continue;
+	for (const user of usersWithActivity) {
+		const dateKey = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+		const key = `digest-${mode}/${user.clerkId}/${dateKey}`;
+		const alreadySent = await ctx.runQuery(internal.emails.hasEmailBeenSent, {
+			key,
+		});
+		if (alreadySent) continue;
 
-    await sendMail(
-      ctx,
-      user.email,
-      `Your Sharity activity — ${dateKey}`,
-      React.createElement(DailyDigestEmail, user.data),
-    );
-    await ctx.runMutation(internal.emails.logEmail, { key });
-  }
+		const locale = user.locale;
+		const digestData: DigestData = { ...user.data, locale };
+		await sendMail(
+			ctx,
+			user.email,
+			t(locale, "digest.subject", { date: dateKey }),
+			React.createElement(DailyDigestEmail, digestData),
+		);
+		await ctx.runMutation(internal.emails.logEmail, { key });
+	}
 }
 
 export const sendDailyDigests = internalAction({
-  args: {},
-  handler: async (ctx) => sendDigests(ctx, "daily"),
+	args: {},
+	handler: async (ctx) => sendDigests(ctx, "daily"),
 });
 
 export const sendWeeklyDigests = internalAction({
-  args: {},
-  handler: async (ctx) => sendDigests(ctx, "weekly"),
+	args: {},
+	handler: async (ctx) => sendDigests(ctx, "weekly"),
 });
 
 // ─── 5. Overdue / Missing Alert ───────────────────────────────────────────────
 
 export const sendOverdueAlert = internalAction({
-  args: {
-    claimId: v.id("claims"),
-    alertType: v.union(v.literal("missing"), v.literal("expired")),
-    ownerEmail: v.string(),
-    borrowerEmail: v.string(),
-    ownerData: v.object({
-      recipientName: v.string(),
-      itemName: v.string(),
-      originalEndDate: v.number(),
-      counterpartyName: v.string(),
-      counterpartyContacts: v.object({
-        telegram: v.optional(v.string()),
-        whatsapp: v.optional(v.string()),
-        facebook: v.optional(v.string()),
-        phone: v.optional(v.string()),
-      }),
-      itemId: v.string(),
-      role: v.union(v.literal("owner"), v.literal("borrower")),
-    }),
-    borrowerData: v.object({
-      recipientName: v.string(),
-      itemName: v.string(),
-      originalEndDate: v.number(),
-      counterpartyName: v.string(),
-      counterpartyContacts: v.object({
-        telegram: v.optional(v.string()),
-        whatsapp: v.optional(v.string()),
-        facebook: v.optional(v.string()),
-        phone: v.optional(v.string()),
-      }),
-      itemId: v.string(),
-      role: v.union(v.literal("owner"), v.literal("borrower")),
-    }),
-  },
-  handler: async (ctx, args) => {
-    const keyOwner = `overdue-${args.alertType}-owner/${args.claimId}`;
-    const keyBorrower = `overdue-${args.alertType}-borrower/${args.claimId}`;
+	args: {
+		claimId: v.id("claims"),
+		alertType: v.union(v.literal("missing"), v.literal("expired")),
+		ownerEmail: v.string(),
+		borrowerEmail: v.string(),
+		ownerLocale: localeValidator,
+		borrowerLocale: localeValidator,
+		ownerData: v.object({
+			recipientName: v.string(),
+			itemName: v.string(),
+			originalEndDate: v.number(),
+			counterpartyName: v.string(),
+			counterpartyContacts: v.object({
+				telegram: v.optional(v.string()),
+				whatsapp: v.optional(v.string()),
+				facebook: v.optional(v.string()),
+				phone: v.optional(v.string()),
+			}),
+			itemId: v.string(),
+			role: v.union(v.literal("owner"), v.literal("borrower")),
+		}),
+		borrowerData: v.object({
+			recipientName: v.string(),
+			itemName: v.string(),
+			originalEndDate: v.number(),
+			counterpartyName: v.string(),
+			counterpartyContacts: v.object({
+				telegram: v.optional(v.string()),
+				whatsapp: v.optional(v.string()),
+				facebook: v.optional(v.string()),
+				phone: v.optional(v.string()),
+			}),
+			itemId: v.string(),
+			role: v.union(v.literal("owner"), v.literal("borrower")),
+		}),
+	},
+	handler: async (ctx, args) => {
+		const keyOwner = `overdue-${args.alertType}-owner/${args.claimId}`;
+		const keyBorrower = `overdue-${args.alertType}-borrower/${args.claimId}`;
 
-    const [sentOwner, sentBorrower] = await Promise.all([
-      ctx.runQuery(internal.emails.hasEmailBeenSent, { key: keyOwner }),
-      ctx.runQuery(internal.emails.hasEmailBeenSent, { key: keyBorrower }),
-    ]);
+		const [sentOwner, sentBorrower] = await Promise.all([
+			ctx.runQuery(internal.emails.hasEmailBeenSent, { key: keyOwner }),
+			ctx.runQuery(internal.emails.hasEmailBeenSent, { key: keyBorrower }),
+		]);
 
-    const ownerData = args.ownerData as OverdueAlertData;
-    const borrowerData = args.borrowerData as OverdueAlertData;
-    const subject = `Action needed: "${ownerData.itemName}" is overdue`;
+		const ownerLocale = resolveLocale(args.ownerLocale);
+		const borrowerLocale = resolveLocale(args.borrowerLocale);
+		const ownerData: OverdueAlertData = { ...args.ownerData, locale: ownerLocale };
+		const borrowerData: OverdueAlertData = {
+			...args.borrowerData,
+			locale: borrowerLocale,
+		};
 
-    await Promise.all([
-      !sentOwner
-        ? sendMail(
-            ctx,
-            args.ownerEmail,
-            subject,
-            React.createElement(OverdueAlertEmail, ownerData),
-          ).then(() =>
-            ctx.runMutation(internal.emails.logEmail, { key: keyOwner }),
-          )
-        : Promise.resolve(),
-      !sentBorrower
-        ? sendMail(
-            ctx,
-            args.borrowerEmail,
-            subject,
-            React.createElement(OverdueAlertEmail, borrowerData),
-          ).then(() =>
-            ctx.runMutation(internal.emails.logEmail, { key: keyBorrower }),
-          )
-        : Promise.resolve(),
-    ]);
-  },
+		await Promise.all([
+			!sentOwner
+				? sendMail(
+						ctx,
+						args.ownerEmail,
+						t(ownerLocale, "overdueAlert.subject", { itemName: ownerData.itemName }),
+						React.createElement(OverdueAlertEmail, ownerData),
+					).then(() =>
+						ctx.runMutation(internal.emails.logEmail, { key: keyOwner }),
+					)
+				: Promise.resolve(),
+			!sentBorrower
+				? sendMail(
+						ctx,
+						args.borrowerEmail,
+						t(borrowerLocale, "overdueAlert.subject", {
+							itemName: borrowerData.itemName,
+						}),
+						React.createElement(OverdueAlertEmail, borrowerData),
+					).then(() =>
+						ctx.runMutation(internal.emails.logEmail, { key: keyBorrower }),
+					)
+				: Promise.resolve(),
+		]);
+	},
 });
 
 // ─── 6. New Request ──────────────────────────────────────────────────────────
 
 export const sendNewRequest = internalAction({
-  args: {
-    claimId: v.id("claims"),
-    ownerEmail: v.string(),
-    data: v.object({
-      ownerName: v.string(),
-      borrowerName: v.string(),
-      itemName: v.string(),
-      startDate: v.number(),
-      endDate: v.number(),
-      itemId: v.string(),
-    }),
-  },
-  handler: async (ctx, args) => {
-    const key = `new-request/${args.claimId}`;
-    const alreadySent = await ctx.runQuery(internal.emails.hasEmailBeenSent, {
-      key,
-    });
-    if (alreadySent) return;
+	args: {
+		claimId: v.id("claims"),
+		ownerEmail: v.string(),
+		locale: localeValidator,
+		data: v.object({
+			ownerName: v.string(),
+			borrowerName: v.string(),
+			itemName: v.string(),
+			startDate: v.number(),
+			endDate: v.number(),
+			itemId: v.string(),
+		}),
+	},
+	handler: async (ctx, args) => {
+		const key = `new-request/${args.claimId}`;
+		const alreadySent = await ctx.runQuery(internal.emails.hasEmailBeenSent, {
+			key,
+		});
+		if (alreadySent) return;
 
-    const data: NewRequestData = args.data;
-    await sendMail(
-      ctx,
-      args.ownerEmail,
-      `New request for "${data.itemName}"`,
-      React.createElement(NewRequestEmail, data),
-    );
-    await ctx.runMutation(internal.emails.logEmail, { key });
-  },
+		const locale = resolveLocale(args.locale);
+		const data: NewRequestData = { ...args.data, locale };
+		await sendMail(
+			ctx,
+			args.ownerEmail,
+			t(locale, "newRequest.subject", { itemName: data.itemName }),
+			React.createElement(NewRequestEmail, data),
+		);
+		await ctx.runMutation(internal.emails.logEmail, { key });
+	},
 });
 
 // ─── 7. Request Rejected ─────────────────────────────────────────────────────
 
 export const sendRequestRejected = internalAction({
-  args: {
-    claimId: v.id("claims"),
-    borrowerEmail: v.string(),
-    data: v.object({
-      borrowerName: v.string(),
-      itemName: v.string(),
-      startDate: v.number(),
-      endDate: v.number(),
-    }),
-  },
-  handler: async (ctx, args) => {
-    const key = `request-rejected/${args.claimId}`;
-    const alreadySent = await ctx.runQuery(internal.emails.hasEmailBeenSent, {
-      key,
-    });
-    if (alreadySent) return;
+	args: {
+		claimId: v.id("claims"),
+		borrowerEmail: v.string(),
+		locale: localeValidator,
+		data: v.object({
+			borrowerName: v.string(),
+			itemName: v.string(),
+			startDate: v.number(),
+			endDate: v.number(),
+		}),
+	},
+	handler: async (ctx, args) => {
+		const key = `request-rejected/${args.claimId}`;
+		const alreadySent = await ctx.runQuery(internal.emails.hasEmailBeenSent, {
+			key,
+		});
+		if (alreadySent) return;
 
-    const data: RequestRejectedData = args.data;
-    await sendMail(
-      ctx,
-      args.borrowerEmail,
-      `Your request for "${data.itemName}" was not approved`,
-      React.createElement(RequestRejectedEmail, data),
-    );
-    await ctx.runMutation(internal.emails.logEmail, { key });
-  },
+		const locale = resolveLocale(args.locale);
+		const data: RequestRejectedData = { ...args.data, locale };
+		await sendMail(
+			ctx,
+			args.borrowerEmail,
+			t(locale, "requestRejected.subject", { itemName: data.itemName }),
+			React.createElement(RequestRejectedEmail, data),
+		);
+		await ctx.runMutation(internal.emails.logEmail, { key });
+	},
 });
 
 // ─── 8. Meetup Proposed ──────────────────────────────────────────────────────
 
 export const sendMeetupProposed = internalAction({
-  args: {
-    claimId: v.id("claims"),
-    meetupType: v.union(v.literal("pickup"), v.literal("return")),
-    recipientEmail: v.string(),
-    data: v.object({
-      recipientName: v.string(),
-      proposerName: v.string(),
-      itemName: v.string(),
-      windowStartAt: v.number(),
-      windowEndAt: v.number(),
-      itemId: v.string(),
-      meetupType: v.union(v.literal("pickup"), v.literal("return")),
-    }),
-  },
-  handler: async (ctx, args) => {
-    const key = `meetup-${args.meetupType}-proposed/${args.claimId}/${args.data.windowStartAt}`;
-    const alreadySent = await ctx.runQuery(internal.emails.hasEmailBeenSent, {
-      key,
-    });
-    if (alreadySent) return;
+	args: {
+		claimId: v.id("claims"),
+		meetupType: v.union(v.literal("pickup"), v.literal("return")),
+		recipientEmail: v.string(),
+		locale: localeValidator,
+		data: v.object({
+			recipientName: v.string(),
+			proposerName: v.string(),
+			itemName: v.string(),
+			windowStartAt: v.number(),
+			windowEndAt: v.number(),
+			itemId: v.string(),
+			meetupType: v.union(v.literal("pickup"), v.literal("return")),
+		}),
+	},
+	handler: async (ctx, args) => {
+		const key = `meetup-${args.meetupType}-proposed/${args.claimId}/${args.data.windowStartAt}`;
+		const alreadySent = await ctx.runQuery(internal.emails.hasEmailBeenSent, {
+			key,
+		});
+		if (alreadySent) return;
 
-    const data: MeetupProposedData = args.data;
-    const typeLabel = args.meetupType === "pickup" ? "Pickup" : "Return";
-    await sendMail(
-      ctx,
-      args.recipientEmail,
-      `${typeLabel} time proposed for "${data.itemName}"`,
-      React.createElement(MeetupProposedEmail, data),
-    );
-    await ctx.runMutation(internal.emails.logEmail, { key });
-  },
+		const locale = resolveLocale(args.locale);
+		const typeKey = args.meetupType === "pickup" ? "pickup" : "return";
+		const data: MeetupProposedData = { ...args.data, locale };
+		await sendMail(
+			ctx,
+			args.recipientEmail,
+			t(locale, `meetupProposed.subject.${typeKey}`, { itemName: data.itemName }),
+			React.createElement(MeetupProposedEmail, data),
+		);
+		await ctx.runMutation(internal.emails.logEmail, { key });
+	},
 });
 
 // ─── 9. Item Available ───────────────────────────────────────────────────────
 
 export const sendItemAvailable = internalAction({
-  args: {
-    itemId: v.id("items"),
-    recipientClerkId: v.string(),
-    recipientEmail: v.string(),
-    data: v.object({
-      recipientName: v.string(),
-      itemName: v.string(),
-      itemId: v.string(),
-    }),
-  },
-  handler: async (ctx, args) => {
-    const key = `item-available/${args.itemId}/${args.recipientClerkId}`;
-    const alreadySent = await ctx.runQuery(internal.emails.hasEmailBeenSent, {
-      key,
-    });
-    if (alreadySent) return;
+	args: {
+		itemId: v.id("items"),
+		recipientClerkId: v.string(),
+		recipientEmail: v.string(),
+		locale: localeValidator,
+		data: v.object({
+			recipientName: v.string(),
+			itemName: v.string(),
+			itemId: v.string(),
+		}),
+	},
+	handler: async (ctx, args) => {
+		const key = `item-available/${args.itemId}/${args.recipientClerkId}`;
+		const alreadySent = await ctx.runQuery(internal.emails.hasEmailBeenSent, {
+			key,
+		});
+		if (alreadySent) return;
 
-    const data: ItemAvailableData = args.data;
-    await sendMail(
-      ctx,
-      args.recipientEmail,
-      `"${data.itemName}" is available again!`,
-      React.createElement(ItemAvailableEmail, data),
-    );
-    await ctx.runMutation(internal.emails.logEmail, { key });
-  },
+		const locale = resolveLocale(args.locale);
+		const data: ItemAvailableData = { ...args.data, locale };
+		await sendMail(
+			ctx,
+			args.recipientEmail,
+			t(locale, "itemAvailable.subject", { itemName: data.itemName }),
+			React.createElement(ItemAvailableEmail, data),
+		);
+		await ctx.runMutation(internal.emails.logEmail, { key });
+	},
 });

--- a/convex/emailTemplates/_shared.tsx
+++ b/convex/emailTemplates/_shared.tsx
@@ -1,242 +1,222 @@
 import {
-  Body,
-  Container,
-  Head,
-  Hr,
-  Html,
-  Img,
-  Link,
-  Preview,
-  Section,
-  Text,
+	Body,
+	Container,
+	Head,
+	Hr,
+	Html,
+	Link,
+	Preview,
+	Section,
+	Text,
 } from "@react-email/components";
 import * as React from "react";
+import { t } from "./i18n";
+import type { Locale } from "./i18n";
 
 // ─── Theme ────────────────────────────────────────────────────────────────────
 
 export const COLORS = {
-  brand: "#2b4f4e",
-  heading: "#1f3d3c",
-  body: "#3d5a59",
-  background: "#f5f2ed",
-  content: "#ffffff",
-  card: "#eef5f4",
-  button: "#2b4f4e",
-  buttonText: "#ffffff",
-  accent: "#c9a04c",
-  accentText: "#1f3d3c",
-  danger: "#c53030",
-  dangerText: "#ffffff",
-  muted: "#6b8a89",
-  border: "#d4e0df",
+	brand: "#2b4f4e",
+	heading: "#1f3d3c",
+	body: "#3d5a59",
+	background: "#f5f2ed",
+	content: "#ffffff",
+	card: "#eef5f4",
+	button: "#2b4f4e",
+	buttonText: "#ffffff",
+	accent: "#c9a04c",
+	accentText: "#1f3d3c",
+	danger: "#c53030",
+	dangerText: "#ffffff",
+	muted: "#6b8a89",
+	border: "#d4e0df",
 };
 
 // ─── Shared types ─────────────────────────────────────────────────────────────
 
+export type { Locale };
+
 export interface ContactInfo {
-  telegram?: string;
-  whatsapp?: string;
-  facebook?: string;
-  phone?: string;
+	telegram?: string;
+	whatsapp?: string;
+	facebook?: string;
+	phone?: string;
 }
 
 export interface DigestNotification {
-  type: string;
-  itemName: string;
-  createdAt: number;
-  itemId: string;
+	type: string;
+	itemName: string;
+	createdAt: number;
+	itemId: string;
 }
 
 export interface DigestItemSummary {
-  itemName: string;
-  itemId: string;
-  events: Array<{ type: string; count: number }>;
+	itemName: string;
+	itemId: string;
+	events: Array<{ type: string; count: number }>;
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 export function appUrl(path: string): string {
-  const base = process.env.NEXT_PUBLIC_APP_URL ?? "https://sharity-dalat.com";
-  return `${base}${path}`;
-}
-
-export function pad(n: number): string {
-  return String(n).padStart(2, "0");
-}
-
-export function formatDate(ts: number): string {
-  const d = new Date(ts);
-  return d.toLocaleDateString("en-US", {
-    weekday: "short",
-    month: "short",
-    day: "numeric",
-  });
-}
-
-export function formatWindow(startTs: number, endTs: number): string {
-  const s = new Date(startTs);
-  const e = new Date(endTs);
-  return `${formatDate(startTs)}, ${pad(s.getHours())}:${pad(s.getMinutes())}–${pad(e.getHours())}:${pad(e.getMinutes())}`;
-}
-
-export function contactLines(contacts: ContactInfo): string {
-  const lines: string[] = [];
-  if (contacts.telegram) lines.push(`Telegram: @${contacts.telegram}`);
-  if (contacts.whatsapp) lines.push(`WhatsApp: ${contacts.whatsapp}`);
-  if (contacts.facebook) lines.push(`Facebook: ${contacts.facebook}`);
-  if (contacts.phone) lines.push(`Phone: ${contacts.phone}`);
-  return lines.length > 0 ? lines.join("\n") : "No contact info provided.";
+	const base = process.env.NEXT_PUBLIC_APP_URL ?? "https://sharity-dalat.com";
+	return `${base}${path}`;
 }
 
 // ─── Shared layout components ─────────────────────────────────────────────────
 
 export function EmailHeader() {
-  return (
-    <>
-      <Section
-        style={{
-          backgroundColor: COLORS.brand,
-          padding: "16px 24px",
-        }}
-      >
-        <Text
-          style={{
-            color: "#ffffff",
-            fontSize: "18px",
-            fontWeight: "700",
-            margin: "0",
-            letterSpacing: "-0.3px",
-          }}
-        >
-          Sharity
-        </Text>
-      </Section>
-      <Section
-        style={{
-          height: "3px",
-          backgroundColor: COLORS.accent,
-        }}
-      />
-    </>
-  );
+	return (
+		<>
+			<Section
+				style={{
+					backgroundColor: COLORS.brand,
+					padding: "16px 24px",
+				}}
+			>
+				<Text
+					style={{
+						color: "#ffffff",
+						fontSize: "18px",
+						fontWeight: "700",
+						margin: "0",
+						letterSpacing: "-0.3px",
+					}}
+				>
+					Sharity
+				</Text>
+			</Section>
+			<Section
+				style={{
+					height: "3px",
+					backgroundColor: COLORS.accent,
+				}}
+			/>
+		</>
+	);
 }
 
-export function EmailFooter() {
-  return (
-    <>
-      <Hr style={{ borderColor: COLORS.border, margin: "24px 0 16px" }} />
-      <Text
-        style={{
-          color: COLORS.muted,
-          fontSize: "12px",
-          textAlign: "center" as const,
-          margin: "0",
-        }}
-      >
-        <Link href={appUrl("/")} style={{ color: COLORS.muted }}>
-          Sharity
-        </Link>{" "}
-        · The community sharing platform
-      </Text>
-    </>
-  );
+interface EmailFooterProps {
+	locale: Locale;
+}
+
+export function EmailFooter({ locale }: EmailFooterProps) {
+	return (
+		<>
+			<Hr style={{ borderColor: COLORS.border, margin: "24px 0 16px" }} />
+			<Text
+				style={{
+					color: COLORS.muted,
+					fontSize: "12px",
+					textAlign: "center" as const,
+					margin: "0",
+				}}
+			>
+				<Link href={appUrl("/")} style={{ color: COLORS.muted }}>
+					Sharity
+				</Link>{" "}
+				· {t(locale, "shared.footer")}
+			</Text>
+		</>
+	);
 }
 
 interface SharityEmailProps {
-  preview: string;
-  children: React.ReactNode;
+	preview: string;
+	locale: Locale;
+	children: React.ReactNode;
 }
 
-export function SharityEmail({ preview, children }: SharityEmailProps) {
-  return (
-    <Html>
-      <Head />
-      <Preview>{preview}</Preview>
-      <Body
-        style={{
-          backgroundColor: COLORS.background,
-          fontFamily:
-            '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
-          margin: "0",
-          padding: "24px 0",
-        }}
-      >
-        <Container
-          style={{
-            maxWidth: "600px",
-            margin: "0 auto",
-            backgroundColor: COLORS.content,
-            borderRadius: "8px",
-            overflow: "hidden",
-            boxShadow: "0 1px 3px rgba(0,0,0,0.08)",
-          }}
-        >
-          <EmailHeader />
-          <Section style={{ padding: "24px" }}>{children}</Section>
-          <Section style={{ padding: "0 24px 24px" }}>
-            <EmailFooter />
-          </Section>
-        </Container>
-      </Body>
-    </Html>
-  );
+export function SharityEmail({ preview, locale, children }: SharityEmailProps) {
+	return (
+		<Html>
+			<Head />
+			<Preview>{preview}</Preview>
+			<Body
+				style={{
+					backgroundColor: COLORS.background,
+					fontFamily:
+						'-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+					margin: "0",
+					padding: "24px 0",
+				}}
+			>
+				<Container
+					style={{
+						maxWidth: "600px",
+						margin: "0 auto",
+						backgroundColor: COLORS.content,
+						borderRadius: "8px",
+						overflow: "hidden",
+						boxShadow: "0 1px 3px rgba(0,0,0,0.08)",
+					}}
+				>
+					<EmailHeader />
+					<Section style={{ padding: "24px" }}>{children}</Section>
+					<Section style={{ padding: "0 24px 24px" }}>
+						<EmailFooter locale={locale} />
+					</Section>
+				</Container>
+			</Body>
+		</Html>
+	);
 }
 
 // ─── Callout box ──────────────────────────────────────────────────────────────
 
 interface CalloutProps {
-  children: React.ReactNode;
-  danger?: boolean;
+	children: React.ReactNode;
+	danger?: boolean;
 }
 
 export function Callout({ children, danger = false }: CalloutProps) {
-  return (
-    <Section
-      style={{
-        backgroundColor: danger ? COLORS.danger : COLORS.card,
-        borderRadius: "6px",
-        padding: "12px 16px",
-        margin: "16px 0",
-      }}
-    >
-      <Text
-        style={{
-          color: danger ? COLORS.dangerText : COLORS.body,
-          fontSize: "14px",
-          margin: "0",
-        }}
-      >
-        {children}
-      </Text>
-    </Section>
-  );
+	return (
+		<Section
+			style={{
+				backgroundColor: danger ? COLORS.danger : COLORS.card,
+				borderRadius: "6px",
+				padding: "12px 16px",
+				margin: "16px 0",
+			}}
+		>
+			<Text
+				style={{
+					color: danger ? COLORS.dangerText : COLORS.body,
+					fontSize: "14px",
+					margin: "0",
+				}}
+			>
+				{children}
+			</Text>
+		</Section>
+	);
 }
 
 // ─── Button ───────────────────────────────────────────────────────────────────
 
 interface EmailButtonProps {
-  href: string;
-  children: React.ReactNode;
+	href: string;
+	children: React.ReactNode;
 }
 
 export function EmailButton({ href, children }: EmailButtonProps) {
-  return (
-    <Section style={{ textAlign: "center" as const, margin: "20px 0" }}>
-      <Link
-        href={href}
-        style={{
-          backgroundColor: COLORS.button,
-          color: COLORS.buttonText,
-          padding: "10px 24px",
-          borderRadius: "6px",
-          fontSize: "14px",
-          fontWeight: "600",
-          textDecoration: "none",
-          display: "inline-block",
-        }}
-      >
-        {children}
-      </Link>
-    </Section>
-  );
+	return (
+		<Section style={{ textAlign: "center" as const, margin: "20px 0" }}>
+			<Link
+				href={href}
+				style={{
+					backgroundColor: COLORS.button,
+					color: COLORS.buttonText,
+					padding: "10px 24px",
+					borderRadius: "6px",
+					fontSize: "14px",
+					fontWeight: "600",
+					textDecoration: "none",
+					display: "inline-block",
+				}}
+			>
+				{children}
+			</Link>
+		</Section>
+	);
 }

--- a/convex/emailTemplates/dailyDigest.tsx
+++ b/convex/emailTemplates/dailyDigest.tsx
@@ -2,134 +2,112 @@ import { Link, Section, Text } from "@react-email/components";
 import * as React from "react";
 import { EmailButton, SharityEmail, COLORS } from "./_shared";
 import type { DigestItemSummary } from "./_shared";
+import { t, pluralize, formatDateLocalized } from "./i18n";
+import type { Locale } from "./i18n";
 
 export interface DigestData {
-  userName: string;
-  mode: "daily" | "weekly";
-  ownerNotifications: DigestItemSummary[];
-  borrowerNotifications: DigestItemSummary[];
-  generalNotifications: DigestItemSummary[];
-}
-
-const NOTIFICATION_LABELS: Record<
-  string,
-  { singular: string; plural: string }
-> = {
-  new_request: { singular: "new request", plural: "new requests" },
-  request_approved: {
-    singular: "request approved",
-    plural: "requests approved",
-  },
-  request_rejected: {
-    singular: "request rejected",
-    plural: "requests rejected",
-  },
-  item_available: { singular: "now available", plural: "now available" },
-  pickup_proposed: { singular: "pickup proposed", plural: "pickups proposed" },
-  pickup_approved: { singular: "pickup approved", plural: "pickups approved" },
-  pickup_expired: { singular: "pickup expired", plural: "pickups expired" },
-  return_proposed: { singular: "return proposed", plural: "returns proposed" },
-  return_approved: { singular: "return approved", plural: "returns approved" },
-  return_missing: { singular: "overdue return", plural: "overdue returns" },
-  rate_transaction: {
-    singular: "rating requested",
-    plural: "ratings requested",
-  },
-  rating_received: { singular: "rating received", plural: "ratings received" },
-};
-
-function eventLabel(type: string, count: number): string {
-  const labels = NOTIFICATION_LABELS[type];
-  if (!labels) return `${count} ${type}`;
-  return `${count} ${count === 1 ? labels.singular : labels.plural}`;
+	userName: string;
+	mode: "daily" | "weekly";
+	ownerNotifications: DigestItemSummary[];
+	borrowerNotifications: DigestItemSummary[];
+	generalNotifications: DigestItemSummary[];
+	locale: Locale;
 }
 
 function DigestSection({
-  heading,
-  items,
+	heading,
+	items,
+	locale,
 }: {
-  heading: string;
-  items: DigestItemSummary[];
+	heading: string;
+	items: DigestItemSummary[];
+	locale: Locale;
 }) {
-  const base = process.env.NEXT_PUBLIC_APP_URL ?? "https://sharity-dalat.com";
-  return (
-    <Section style={{ margin: "16px 0 8px" }}>
-      <Text
-        style={{
-          fontSize: "15px",
-          fontWeight: "700",
-          color: COLORS.heading,
-          margin: "0 0 8px",
-        }}
-      >
-        {heading}
-      </Text>
-      {items.map((item, i) => {
-        const url = `${base}/item/${item.itemId}`;
-        const summary = item.events
-          .map((e) => eventLabel(e.type, e.count))
-          .join(", ");
-        return (
-          <Text
-            key={i}
-            style={{ color: COLORS.body, fontSize: "14px", margin: "4px 0" }}
-          >
-            •{" "}
-            <Link href={url} style={{ color: COLORS.brand }}>
-              <strong>{item.itemName}</strong>
-            </Link>{" "}
-            — {summary}
-          </Text>
-        );
-      })}
-    </Section>
-  );
+	const base = process.env.NEXT_PUBLIC_APP_URL ?? "https://sharity-dalat.com";
+	return (
+		<Section style={{ margin: "16px 0 8px" }}>
+			<Text
+				style={{
+					fontSize: "15px",
+					fontWeight: "700",
+					color: COLORS.heading,
+					margin: "0 0 8px",
+				}}
+			>
+				{heading}
+			</Text>
+			{items.map((item, i) => {
+				const url = `${base}/item/${item.itemId}`;
+				const summary = item.events
+					.map((e) => pluralize(locale, `digest.event.${e.type}`, e.count))
+					.join(", ");
+				return (
+					<Text
+						key={i}
+						style={{ color: COLORS.body, fontSize: "14px", margin: "4px 0" }}
+					>
+						•{" "}
+						<Link href={url} style={{ color: COLORS.brand }}>
+							<strong>{item.itemName}</strong>
+						</Link>{" "}
+						— {summary}
+					</Text>
+				);
+			})}
+		</Section>
+	);
 }
 
 export function DailyDigestEmail(data: DigestData) {
-  const base = process.env.NEXT_PUBLIC_APP_URL ?? "https://sharity-dalat.com";
-  const today = new Date().toLocaleDateString("en-US", {
-    weekday: "long",
-    month: "long",
-    day: "numeric",
-  });
+	const base = process.env.NEXT_PUBLIC_APP_URL ?? "https://sharity-dalat.com";
+	const today = formatDateLocalized(Date.now(), data.locale);
 
-  const isWeekly = data.mode === "weekly";
-  const title = isWeekly
-    ? `Weekly Summary — ${today}`
-    : `Daily Summary — ${today}`;
-  const period = isWeekly ? "this past week" : "the last 24 hours";
+	const titleKey = data.mode === "weekly" ? "digest.title.weekly" : "digest.title.daily";
+	const introKey = data.mode === "weekly" ? "digest.intro.weekly" : "digest.intro.daily";
+	const title = t(data.locale, titleKey, { date: today });
 
-  return (
-    <SharityEmail preview={`Your Sharity activity — ${today}`}>
-      <Text
-        style={{
-          fontSize: "22px",
-          fontWeight: "700",
-          color: COLORS.heading,
-          margin: "0 0 8px",
-        }}
-      >
-        {title}
-      </Text>
-      <Text
-        style={{ color: COLORS.body, fontSize: "15px", margin: "0 0 16px" }}
-      >
-        Hi {data.userName}, here&apos;s what happened on Sharity in {period}:
-      </Text>
-      {data.ownerNotifications.length > 0 && (
-        <DigestSection heading="As Owner" items={data.ownerNotifications} />
-      )}
-      {data.borrowerNotifications.length > 0 && (
-        <DigestSection
-          heading="As Borrower"
-          items={data.borrowerNotifications}
-        />
-      )}
-      {data.generalNotifications.length > 0 && (
-        <DigestSection heading="General" items={data.generalNotifications} />
-      )}
-      <EmailButton href={base}>Go to Sharity</EmailButton>
-    </SharityEmail>
-  );
+	return (
+		<SharityEmail
+			preview={t(data.locale, "digest.preview", { date: today })}
+			locale={data.locale}
+		>
+			<Text
+				style={{
+					fontSize: "22px",
+					fontWeight: "700",
+					color: COLORS.heading,
+					margin: "0 0 8px",
+				}}
+			>
+				{title}
+			</Text>
+			<Text
+				style={{ color: COLORS.body, fontSize: "15px", margin: "0 0 16px" }}
+			>
+				{t(data.locale, introKey, { userName: data.userName })}
+			</Text>
+			{data.ownerNotifications.length > 0 && (
+				<DigestSection
+					heading={t(data.locale, "digest.section.owner")}
+					items={data.ownerNotifications}
+					locale={data.locale}
+				/>
+			)}
+			{data.borrowerNotifications.length > 0 && (
+				<DigestSection
+					heading={t(data.locale, "digest.section.borrower")}
+					items={data.borrowerNotifications}
+					locale={data.locale}
+				/>
+			)}
+			{data.generalNotifications.length > 0 && (
+				<DigestSection
+					heading={t(data.locale, "digest.section.general")}
+					items={data.generalNotifications}
+					locale={data.locale}
+				/>
+			)}
+			<EmailButton href={base}>{t(data.locale, "digest.cta")}</EmailButton>
+		</SharityEmail>
+	);
 }

--- a/convex/emailTemplates/i18n.ts
+++ b/convex/emailTemplates/i18n.ts
@@ -1,0 +1,578 @@
+export type Locale = "en" | "vi" | "ru";
+
+// ─── Date/time formatting ─────────────────────────────────────────────────────
+
+const DATE_FORMAT_OPTIONS: Record<
+	Locale,
+	Intl.DateTimeFormatOptions & { locale: string }
+> = {
+	en: {
+		locale: "en-US",
+		weekday: "short",
+		month: "short",
+		day: "numeric",
+	},
+	vi: {
+		locale: "vi-VN",
+		weekday: "short",
+		day: "numeric",
+		month: "short",
+	},
+	ru: {
+		locale: "ru-RU",
+		weekday: "short",
+		day: "numeric",
+		month: "short",
+	},
+};
+
+function pad(n: number): string {
+	return String(n).padStart(2, "0");
+}
+
+export function formatDateLocalized(ts: number, locale: Locale): string {
+	const { locale: intlLocale, ...opts } = DATE_FORMAT_OPTIONS[locale];
+	return new Date(ts).toLocaleDateString(intlLocale, opts);
+}
+
+export function formatWindowLocalized(
+	startTs: number,
+	endTs: number,
+	locale: Locale,
+): string {
+	const s = new Date(startTs);
+	const e = new Date(endTs);
+	return `${formatDateLocalized(startTs, locale)}, ${pad(s.getHours())}:${pad(s.getMinutes())}–${pad(e.getHours())}:${pad(e.getMinutes())}`;
+}
+
+// ─── Translation strings ──────────────────────────────────────────────────────
+
+const emailStrings: Record<Locale, Record<string, string>> = {
+	en: {
+		// ── Shared ──
+		"shared.footer": "The community sharing platform",
+		"shared.contactNone": "No contact info provided.",
+		"shared.contactTelegram": "Telegram: @{handle}",
+		"shared.contactWhatsapp": "WhatsApp: {number}",
+		"shared.contactFacebook": "Facebook: {profile}",
+		"shared.contactPhone": "Phone: {number}",
+
+		// ── Welcome ──
+		"welcome.subject": "Welcome to Sharity!",
+		"welcome.preview": "Welcome to Sharity, {name}!",
+		"welcome.heading": "Hey {name}!",
+		"welcome.intro":
+			"Welcome to Sharity — a community where neighbours share things they own but rarely use.",
+		"welcome.canDoIntro": "Here's what you can do:",
+		"welcome.bullet.browse":
+			"Browse items — find something you need without buying it",
+		"welcome.bullet.list": "List your stuff — put idle items to good use",
+		"welcome.bullet.request":
+			"Request a loan — pick dates, get approved, arrange pickup",
+		"welcome.cta": "Explore Items",
+		"welcome.callout":
+			"No money changes hands. Sharity runs on trust and community goodwill.",
+
+		// ── New Request ──
+		"newRequest.subject": 'New request for "{itemName}"',
+		"newRequest.preview": 'New request for "{itemName}"',
+		"newRequest.heading": "New Borrow Request",
+		"newRequest.greeting": "Hi {ownerName},",
+		"newRequest.body":
+			"{borrowerName} wants to borrow your item {itemName} for {dateRange}.",
+		"newRequest.callout":
+			"Review the request and approve or decline it so the borrower can plan ahead.",
+		"newRequest.cta": "Review Request",
+		"newRequest.footer":
+			"You have up to the start date to respond. Unanswered requests expire automatically.",
+
+		// ── Lease Approved ──
+		"leaseApproved.subject": 'Your request for "{itemName}" was approved',
+		"leaseApproved.preview": 'Your request for "{itemName}" was approved',
+		"leaseApproved.heading": "Request Approved",
+		"leaseApproved.greeting": "Hi {borrowerName},",
+		"leaseApproved.body":
+			"Your request for {itemName} has been approved for {dateRange}.",
+		"leaseApproved.callout":
+			"Next step: Propose a pickup window so you and the owner can coordinate the handover.",
+		"leaseApproved.cta": "Propose Pickup Time",
+		"leaseApproved.footer":
+			"If you can no longer make it, you can cancel your request on the item page.",
+
+		// ── Request Rejected ──
+		"requestRejected.subject":
+			'Your request for "{itemName}" was not approved',
+		"requestRejected.preview":
+			'Your request for "{itemName}" was not approved',
+		"requestRejected.heading": "Request Not Approved",
+		"requestRejected.greeting": "Hi {borrowerName},",
+		"requestRejected.body":
+			"Unfortunately, the owner declined your request for {itemName} ({dateRange}).",
+		"requestRejected.callout":
+			"Don't worry — there are plenty of other items available on Sharity. Browse the catalogue to find what you need.",
+		"requestRejected.cta": "Browse Other Items",
+
+		// ── Meetup Proposed ──
+		"meetupProposed.subject.pickup":
+			'Pickup time proposed for "{itemName}"',
+		"meetupProposed.subject.return":
+			'Return time proposed for "{itemName}"',
+		"meetupProposed.preview.pickup":
+			'Pickup time proposed for "{itemName}"',
+		"meetupProposed.preview.return":
+			'Return time proposed for "{itemName}"',
+		"meetupProposed.heading.pickup": "Pickup Time Proposed",
+		"meetupProposed.heading.return": "Return Time Proposed",
+		"meetupProposed.greeting": "Hi {recipientName},",
+		"meetupProposed.body.pickup":
+			'{proposerName} proposed a time to pick up "{itemName}":',
+		"meetupProposed.body.return":
+			'{proposerName} proposed a time to return "{itemName}":',
+		"meetupProposed.callout":
+			"Review and approve this time so both parties can confirm the meetup.",
+		"meetupProposed.cta": "Review & Approve",
+		"meetupProposed.footer":
+			"If this time doesn't work, you can propose a different window on the item page.",
+
+		// ── Meetup Confirmed ──
+		"meetupConfirmed.subject": 'Meetup confirmed for "{itemName}"',
+		"meetupConfirmed.preview": 'Meetup confirmed for "{itemName}"',
+		"meetupConfirmed.heading": "Meetup Confirmed",
+		"meetupConfirmed.greeting": "Hi {recipientName},",
+		"meetupConfirmed.body.pickup":
+			'Your meetup to pick up "{itemName}" is confirmed:',
+		"meetupConfirmed.body.return":
+			'Your meetup to return "{itemName}" is confirmed:',
+		"meetupConfirmed.whoToMeet": "Who to meet: {name}",
+		"meetupConfirmed.contactInfo": "Their contact info:",
+		"meetupConfirmed.cta": "View Item",
+		"meetupConfirmed.callout.pickup":
+			"After the meetup, mark the item as picked up on the item page to complete the handover.",
+		"meetupConfirmed.callout.return":
+			"After the meetup, mark the item as returned on the item page to complete the handover.",
+
+		// ── Overdue Alert ──
+		"overdueAlert.subject": 'Action needed: "{itemName}" is overdue',
+		"overdueAlert.preview": 'Action needed: "{itemName}" is overdue',
+		"overdueAlert.badge": "Overdue Item",
+		"overdueAlert.headline.owner":
+			'"{itemName}" has not been returned',
+		"overdueAlert.headline.borrower":
+			'You have an overdue item: "{itemName}"',
+		"overdueAlert.greeting": "Hi {recipientName},",
+		"overdueAlert.body.owner":
+			"The return window has passed (due {dueDate}). Please contact the borrower to arrange the return.",
+		"overdueAlert.body.borrower":
+			"Your borrow of {itemName} was due back on {dueDate}. Please contact the owner to arrange the return as soon as possible.",
+		"overdueAlert.contactLabel": "Contact {counterpartyName}:",
+		"overdueAlert.cta": "View Item",
+		"overdueAlert.support":
+			"If you cannot reach the other party, please contact Sharity support.",
+
+		// ── Item Available ──
+		"itemAvailable.subject": '"{itemName}" is available again!',
+		"itemAvailable.preview": '"{itemName}" is available again!',
+		"itemAvailable.heading": "Item Available!",
+		"itemAvailable.greeting": "Hi {recipientName},",
+		"itemAvailable.body":
+			"Great news — {itemName}, the item you were watching, is available again.",
+		"itemAvailable.callout":
+			"Items can be claimed quickly. Request it now before someone else does!",
+		"itemAvailable.cta": "Request It Now",
+
+		// ── Daily / Weekly Digest ──
+		"digest.subject": "Your Sharity activity — {date}",
+		"digest.preview": "Your Sharity activity — {date}",
+		"digest.title.daily": "Daily Summary — {date}",
+		"digest.title.weekly": "Weekly Summary — {date}",
+		"digest.intro.daily":
+			"Hi {userName}, here's what happened on Sharity in the last 24 hours:",
+		"digest.intro.weekly":
+			"Hi {userName}, here's what happened on Sharity this past week:",
+		"digest.section.owner": "As Owner",
+		"digest.section.borrower": "As Borrower",
+		"digest.section.general": "General",
+		"digest.cta": "Go to Sharity",
+		// Notification event labels (singular | plural separated by |)
+		"digest.event.new_request": "new request|new requests",
+		"digest.event.request_approved": "request approved|requests approved",
+		"digest.event.request_rejected": "request rejected|requests rejected",
+		"digest.event.item_available": "now available|now available",
+		"digest.event.pickup_proposed": "pickup proposed|pickups proposed",
+		"digest.event.pickup_approved": "pickup approved|pickups approved",
+		"digest.event.pickup_expired": "pickup expired|pickups expired",
+		"digest.event.return_proposed": "return proposed|returns proposed",
+		"digest.event.return_approved": "return approved|returns approved",
+		"digest.event.return_missing": "overdue return|overdue returns",
+		"digest.event.rate_transaction": "rating requested|ratings requested",
+		"digest.event.rating_received": "rating received|ratings received",
+	},
+
+	vi: {
+		// ── Shared ──
+		"shared.footer": "Nền tảng chia sẻ cộng đồng",
+		"shared.contactNone": "Không có thông tin liên hệ.",
+		"shared.contactTelegram": "Telegram: @{handle}",
+		"shared.contactWhatsapp": "WhatsApp: {number}",
+		"shared.contactFacebook": "Facebook: {profile}",
+		"shared.contactPhone": "Điện thoại: {number}",
+
+		// ── Welcome ──
+		"welcome.subject": "Chào mừng bạn đến với Sharity!",
+		"welcome.preview": "Chào mừng bạn đến với Sharity, {name}!",
+		"welcome.heading": "Xin chào {name}!",
+		"welcome.intro":
+			"Chào mừng bạn đến với Sharity — cộng đồng nơi hàng xóm chia sẻ những đồ vật ít dùng đến.",
+		"welcome.canDoIntro": "Bạn có thể làm gì:",
+		"welcome.bullet.browse":
+			"Tìm kiếm đồ vật — tìm thứ bạn cần mà không cần mua",
+		"welcome.bullet.list":
+			"Đăng đồ của bạn — cho những vật dụng nhàn rỗi được sử dụng",
+		"welcome.bullet.request":
+			"Gửi yêu cầu mượn — chọn ngày, được chấp thuận, sắp xếp nhận hàng",
+		"welcome.cta": "Khám phá đồ vật",
+		"welcome.callout":
+			"Không có giao dịch tiền bạc. Sharity vận hành trên sự tin tưởng và tinh thần cộng đồng.",
+
+		// ── New Request ──
+		"newRequest.subject": 'Yêu cầu mượn mới cho "{itemName}"',
+		"newRequest.preview": 'Yêu cầu mượn mới cho "{itemName}"',
+		"newRequest.heading": "Yêu Cầu Mượn Mới",
+		"newRequest.greeting": "Xin chào {ownerName},",
+		"newRequest.body":
+			"{borrowerName} muốn mượn đồ vật {itemName} của bạn trong thời gian {dateRange}.",
+		"newRequest.callout":
+			"Xem xét yêu cầu và chấp thuận hoặc từ chối để người mượn có thể lên kế hoạch.",
+		"newRequest.cta": "Xem Yêu Cầu",
+		"newRequest.footer":
+			"Bạn có thể phản hồi cho đến ngày bắt đầu. Yêu cầu không được trả lời sẽ tự động hết hạn.",
+
+		// ── Lease Approved ──
+		"leaseApproved.subject": 'Yêu cầu mượn "{itemName}" của bạn đã được chấp thuận',
+		"leaseApproved.preview": 'Yêu cầu mượn "{itemName}" của bạn đã được chấp thuận',
+		"leaseApproved.heading": "Yêu Cầu Đã Được Chấp Thuận",
+		"leaseApproved.greeting": "Xin chào {borrowerName},",
+		"leaseApproved.body":
+			"Yêu cầu mượn {itemName} của bạn đã được chấp thuận cho thời gian {dateRange}.",
+		"leaseApproved.callout":
+			"Bước tiếp theo: Đề xuất khung giờ nhận hàng để bạn và chủ sở hữu có thể phối hợp.",
+		"leaseApproved.cta": "Đề Xuất Giờ Nhận",
+		"leaseApproved.footer":
+			"Nếu bạn không thể đến, bạn có thể hủy yêu cầu trên trang đồ vật.",
+
+		// ── Request Rejected ──
+		"requestRejected.subject": 'Yêu cầu mượn "{itemName}" của bạn không được chấp thuận',
+		"requestRejected.preview": 'Yêu cầu mượn "{itemName}" của bạn không được chấp thuận',
+		"requestRejected.heading": "Yêu Cầu Không Được Chấp Thuận",
+		"requestRejected.greeting": "Xin chào {borrowerName},",
+		"requestRejected.body":
+			"Rất tiếc, chủ sở hữu đã từ chối yêu cầu mượn {itemName} của bạn ({dateRange}).",
+		"requestRejected.callout":
+			"Đừng lo — còn rất nhiều đồ vật khác trên Sharity. Hãy duyệt danh mục để tìm thứ bạn cần.",
+		"requestRejected.cta": "Xem Đồ Vật Khác",
+
+		// ── Meetup Proposed ──
+		"meetupProposed.subject.pickup": 'Đề xuất giờ nhận hàng cho "{itemName}"',
+		"meetupProposed.subject.return": 'Đề xuất giờ trả hàng cho "{itemName}"',
+		"meetupProposed.preview.pickup": 'Đề xuất giờ nhận hàng cho "{itemName}"',
+		"meetupProposed.preview.return": 'Đề xuất giờ trả hàng cho "{itemName}"',
+		"meetupProposed.heading.pickup": "Đề Xuất Giờ Nhận Hàng",
+		"meetupProposed.heading.return": "Đề Xuất Giờ Trả Hàng",
+		"meetupProposed.greeting": "Xin chào {recipientName},",
+		"meetupProposed.body.pickup":
+			'{proposerName} đã đề xuất thời gian nhận "{itemName}":',
+		"meetupProposed.body.return":
+			'{proposerName} đã đề xuất thời gian trả "{itemName}":',
+		"meetupProposed.callout":
+			"Xem xét và xác nhận thời gian này để cả hai bên có thể xác nhận cuộc gặp.",
+		"meetupProposed.cta": "Xem & Xác Nhận",
+		"meetupProposed.footer":
+			"Nếu thời gian này không phù hợp, bạn có thể đề xuất khung giờ khác trên trang đồ vật.",
+
+		// ── Meetup Confirmed ──
+		"meetupConfirmed.subject": 'Cuộc gặp đã được xác nhận cho "{itemName}"',
+		"meetupConfirmed.preview": 'Cuộc gặp đã được xác nhận cho "{itemName}"',
+		"meetupConfirmed.heading": "Cuộc Gặp Đã Xác Nhận",
+		"meetupConfirmed.greeting": "Xin chào {recipientName},",
+		"meetupConfirmed.body.pickup":
+			'Cuộc gặp để nhận "{itemName}" đã được xác nhận:',
+		"meetupConfirmed.body.return":
+			'Cuộc gặp để trả "{itemName}" đã được xác nhận:',
+		"meetupConfirmed.whoToMeet": "Người cần gặp: {name}",
+		"meetupConfirmed.contactInfo": "Thông tin liên hệ của họ:",
+		"meetupConfirmed.cta": "Xem Đồ Vật",
+		"meetupConfirmed.callout.pickup":
+			"Sau cuộc gặp, đánh dấu đồ vật đã nhận trên trang đồ vật để hoàn tất quá trình bàn giao.",
+		"meetupConfirmed.callout.return":
+			"Sau cuộc gặp, đánh dấu đồ vật đã trả trên trang đồ vật để hoàn tất quá trình bàn giao.",
+
+		// ── Overdue Alert ──
+		"overdueAlert.subject": 'Cần hành động: "{itemName}" đã quá hạn',
+		"overdueAlert.preview": 'Cần hành động: "{itemName}" đã quá hạn',
+		"overdueAlert.badge": "Đồ Vật Quá Hạn",
+		"overdueAlert.headline.owner": '"{itemName}" chưa được trả',
+		"overdueAlert.headline.borrower": 'Bạn có đồ vật quá hạn: "{itemName}"',
+		"overdueAlert.greeting": "Xin chào {recipientName},",
+		"overdueAlert.body.owner":
+			"Thời hạn trả đã qua (hạn {dueDate}). Vui lòng liên hệ người mượn để sắp xếp trả hàng.",
+		"overdueAlert.body.borrower":
+			"Đồ vật {itemName} bạn mượn đã hết hạn vào ngày {dueDate}. Vui lòng liên hệ chủ sở hữu để sắp xếp trả hàng sớm nhất.",
+		"overdueAlert.contactLabel": "Liên hệ {counterpartyName}:",
+		"overdueAlert.cta": "Xem Đồ Vật",
+		"overdueAlert.support":
+			"Nếu bạn không thể liên hệ được phía bên kia, vui lòng liên hệ bộ phận hỗ trợ Sharity.",
+
+		// ── Item Available ──
+		"itemAvailable.subject": '"{itemName}" đã có sẵn trở lại!',
+		"itemAvailable.preview": '"{itemName}" đã có sẵn trở lại!',
+		"itemAvailable.heading": "Đồ Vật Đã Có Sẵn!",
+		"itemAvailable.greeting": "Xin chào {recipientName},",
+		"itemAvailable.body":
+			"Tin vui — {itemName}, đồ vật bạn đang theo dõi, đã có sẵn trở lại.",
+		"itemAvailable.callout":
+			"Đồ vật có thể được yêu cầu nhanh chóng. Hãy gửi yêu cầu ngay trước người khác!",
+		"itemAvailable.cta": "Yêu Cầu Ngay",
+
+		// ── Daily / Weekly Digest ──
+		"digest.subject": "Hoạt động Sharity của bạn — {date}",
+		"digest.preview": "Hoạt động Sharity của bạn — {date}",
+		"digest.title.daily": "Tóm Tắt Hàng Ngày — {date}",
+		"digest.title.weekly": "Tóm Tắt Hàng Tuần — {date}",
+		"digest.intro.daily":
+			"Xin chào {userName}, đây là những gì đã xảy ra trên Sharity trong 24 giờ qua:",
+		"digest.intro.weekly":
+			"Xin chào {userName}, đây là những gì đã xảy ra trên Sharity trong tuần qua:",
+		"digest.section.owner": "Với Tư Cách Chủ Sở Hữu",
+		"digest.section.borrower": "Với Tư Cách Người Mượn",
+		"digest.section.general": "Chung",
+		"digest.cta": "Đến Sharity",
+		"digest.event.new_request": "yêu cầu mới|yêu cầu mới",
+		"digest.event.request_approved": "yêu cầu được chấp thuận|yêu cầu được chấp thuận",
+		"digest.event.request_rejected": "yêu cầu bị từ chối|yêu cầu bị từ chối",
+		"digest.event.item_available": "đã có sẵn|đã có sẵn",
+		"digest.event.pickup_proposed": "đề xuất nhận hàng|đề xuất nhận hàng",
+		"digest.event.pickup_approved": "xác nhận nhận hàng|xác nhận nhận hàng",
+		"digest.event.pickup_expired": "nhận hàng hết hạn|nhận hàng hết hạn",
+		"digest.event.return_proposed": "đề xuất trả hàng|đề xuất trả hàng",
+		"digest.event.return_approved": "xác nhận trả hàng|xác nhận trả hàng",
+		"digest.event.return_missing": "trả hàng quá hạn|trả hàng quá hạn",
+		"digest.event.rate_transaction": "yêu cầu đánh giá|yêu cầu đánh giá",
+		"digest.event.rating_received": "nhận đánh giá|nhận đánh giá",
+	},
+
+	ru: {
+		// ── Shared ──
+		"shared.footer": "Платформа совместного использования",
+		"shared.contactNone": "Контактная информация не указана.",
+		"shared.contactTelegram": "Telegram: @{handle}",
+		"shared.contactWhatsapp": "WhatsApp: {number}",
+		"shared.contactFacebook": "Facebook: {profile}",
+		"shared.contactPhone": "Телефон: {number}",
+
+		// ── Welcome ──
+		"welcome.subject": "Добро пожаловать в Sharity!",
+		"welcome.preview": "Добро пожаловать в Sharity, {name}!",
+		"welcome.heading": "Привет, {name}!",
+		"welcome.intro":
+			"Добро пожаловать в Sharity — сообщество, где соседи делятся вещами, которые редко используют.",
+		"welcome.canDoIntro": "Что вы можете делать:",
+		"welcome.bullet.browse":
+			"Искать вещи — найдите то, что нужно, без покупки",
+		"welcome.bullet.list":
+			"Публиковать свои вещи — дайте простаивающим вещам вторую жизнь",
+		"welcome.bullet.request":
+			"Отправить заявку — выберите даты, получите одобрение, договоритесь о встрече",
+		"welcome.cta": "Смотреть вещи",
+		"welcome.callout":
+			"Никаких денег. Sharity работает на доверии и взаимопомощи.",
+
+		// ── New Request ──
+		"newRequest.subject": 'Новая заявка на "{itemName}"',
+		"newRequest.preview": 'Новая заявка на "{itemName}"',
+		"newRequest.heading": "Новая Заявка на Аренду",
+		"newRequest.greeting": "Здравствуйте, {ownerName},",
+		"newRequest.body":
+			"{borrowerName} хочет одолжить вашу вещь {itemName} на период {dateRange}.",
+		"newRequest.callout":
+			"Рассмотрите заявку и одобрите или отклоните её, чтобы арендатор мог планировать.",
+		"newRequest.cta": "Просмотреть заявку",
+		"newRequest.footer":
+			"У вас есть время до даты начала для ответа. Заявки без ответа истекают автоматически.",
+
+		// ── Lease Approved ──
+		"leaseApproved.subject": 'Ваша заявка на "{itemName}" одобрена',
+		"leaseApproved.preview": 'Ваша заявка на "{itemName}" одобрена',
+		"leaseApproved.heading": "Заявка Одобрена",
+		"leaseApproved.greeting": "Здравствуйте, {borrowerName},",
+		"leaseApproved.body":
+			"Ваша заявка на {itemName} одобрена на период {dateRange}.",
+		"leaseApproved.callout":
+			"Следующий шаг: предложите время встречи для получения вещи.",
+		"leaseApproved.cta": "Предложить время получения",
+		"leaseApproved.footer":
+			"Если вы не сможете забрать вещь, отмените заявку на странице вещи.",
+
+		// ── Request Rejected ──
+		"requestRejected.subject": 'Ваша заявка на "{itemName}" не одобрена',
+		"requestRejected.preview": 'Ваша заявка на "{itemName}" не одобрена',
+		"requestRejected.heading": "Заявка Не Одобрена",
+		"requestRejected.greeting": "Здравствуйте, {borrowerName},",
+		"requestRejected.body":
+			"К сожалению, владелец отклонил вашу заявку на {itemName} ({dateRange}).",
+		"requestRejected.callout":
+			"Не расстраивайтесь — на Sharity много других вещей. Просмотрите каталог, чтобы найти нужное.",
+		"requestRejected.cta": "Смотреть другие вещи",
+
+		// ── Meetup Proposed ──
+		"meetupProposed.subject.pickup":
+			'Предложено время получения "{itemName}"',
+		"meetupProposed.subject.return":
+			'Предложено время возврата "{itemName}"',
+		"meetupProposed.preview.pickup":
+			'Предложено время получения "{itemName}"',
+		"meetupProposed.preview.return":
+			'Предложено время возврата "{itemName}"',
+		"meetupProposed.heading.pickup": "Предложено Время Получения",
+		"meetupProposed.heading.return": "Предложено Время Возврата",
+		"meetupProposed.greeting": "Здравствуйте, {recipientName},",
+		"meetupProposed.body.pickup":
+			'{proposerName} предложил время для получения "{itemName}":',
+		"meetupProposed.body.return":
+			'{proposerName} предложил время для возврата "{itemName}":',
+		"meetupProposed.callout":
+			"Рассмотрите и подтвердите это время, чтобы обе стороны могли подтвердить встречу.",
+		"meetupProposed.cta": "Просмотреть и подтвердить",
+		"meetupProposed.footer":
+			"Если это время не подходит, вы можете предложить другое на странице вещи.",
+
+		// ── Meetup Confirmed ──
+		"meetupConfirmed.subject": 'Встреча подтверждена для "{itemName}"',
+		"meetupConfirmed.preview": 'Встреча подтверждена для "{itemName}"',
+		"meetupConfirmed.heading": "Встреча Подтверждена",
+		"meetupConfirmed.greeting": "Здравствуйте, {recipientName},",
+		"meetupConfirmed.body.pickup":
+			'Ваша встреча для получения "{itemName}" подтверждена:',
+		"meetupConfirmed.body.return":
+			'Ваша встреча для возврата "{itemName}" подтверждена:',
+		"meetupConfirmed.whoToMeet": "С кем встречаться: {name}",
+		"meetupConfirmed.contactInfo": "Контактная информация:",
+		"meetupConfirmed.cta": "Просмотреть вещь",
+		"meetupConfirmed.callout.pickup":
+			"После встречи отметьте вещь как полученную на странице вещи для завершения передачи.",
+		"meetupConfirmed.callout.return":
+			"После встречи отметьте вещь как возвращённую на странице вещи для завершения передачи.",
+
+		// ── Overdue Alert ──
+		"overdueAlert.subject": 'Требуется действие: "{itemName}" просрочена',
+		"overdueAlert.preview": 'Требуется действие: "{itemName}" просрочена',
+		"overdueAlert.badge": "Просроченная вещь",
+		"overdueAlert.headline.owner": '"{itemName}" не была возвращена',
+		"overdueAlert.headline.borrower":
+			'У вас есть просроченная вещь: "{itemName}"',
+		"overdueAlert.greeting": "Здравствуйте, {recipientName},",
+		"overdueAlert.body.owner":
+			"Срок возврата истёк ({dueDate}). Пожалуйста, свяжитесь с арендатором для организации возврата.",
+		"overdueAlert.body.borrower":
+			"Срок аренды {itemName} истёк {dueDate}. Пожалуйста, как можно скорее свяжитесь с владельцем для возврата.",
+		"overdueAlert.contactLabel": "Связаться с {counterpartyName}:",
+		"overdueAlert.cta": "Просмотреть вещь",
+		"overdueAlert.support":
+			"Если вы не можете связаться с другой стороной, обратитесь в поддержку Sharity.",
+
+		// ── Item Available ──
+		"itemAvailable.subject": '"{itemName}" снова доступна!',
+		"itemAvailable.preview": '"{itemName}" снова доступна!',
+		"itemAvailable.heading": "Вещь Доступна!",
+		"itemAvailable.greeting": "Здравствуйте, {recipientName},",
+		"itemAvailable.body":
+			"Отличные новости — {itemName}, вещь, за которой вы следите, снова доступна.",
+		"itemAvailable.callout":
+			"Вещи быстро разбирают. Отправьте заявку прямо сейчас, пока не опоздали!",
+		"itemAvailable.cta": "Отправить заявку",
+
+		// ── Daily / Weekly Digest ──
+		"digest.subject": "Ваша активность на Sharity — {date}",
+		"digest.preview": "Ваша активность на Sharity — {date}",
+		"digest.title.daily": "Ежедневная сводка — {date}",
+		"digest.title.weekly": "Еженедельная сводка — {date}",
+		"digest.intro.daily":
+			"Здравствуйте, {userName}, вот что произошло на Sharity за последние 24 часа:",
+		"digest.intro.weekly":
+			"Здравствуйте, {userName}, вот что произошло на Sharity за прошедшую неделю:",
+		"digest.section.owner": "Как владелец",
+		"digest.section.borrower": "Как арендатор",
+		"digest.section.general": "Общее",
+		"digest.cta": "Перейти на Sharity",
+		"digest.event.new_request": "новая заявка|новых заявки|новых заявок",
+		"digest.event.request_approved": "заявка одобрена|заявки одобрены|заявок одобрено",
+		"digest.event.request_rejected": "заявка отклонена|заявки отклонены|заявок отклонено",
+		"digest.event.item_available": "доступна|доступны|доступно",
+		"digest.event.pickup_proposed": "встреча предложена|встречи предложены|встреч предложено",
+		"digest.event.pickup_approved": "встреча подтверждена|встречи подтверждены|встреч подтверждено",
+		"digest.event.pickup_expired": "встреча истекла|встречи истекли|встреч истекло",
+		"digest.event.return_proposed": "возврат предложен|возврата предложены|возвратов предложено",
+		"digest.event.return_approved": "возврат подтверждён|возврата подтверждены|возвратов подтверждено",
+		"digest.event.return_missing": "просроченный возврат|просроченных возврата|просроченных возвратов",
+		"digest.event.rate_transaction": "запрос оценки|запроса оценки|запросов оценки",
+		"digest.event.rating_received": "оценка получена|оценки получены|оценок получено",
+	},
+};
+
+// ─── Translation helpers ───────────────────────────────────────────────────────
+
+export function t(
+	locale: Locale,
+	key: string,
+	params?: Record<string, string>,
+): string {
+	let str = emailStrings[locale]?.[key] ?? emailStrings.en[key] ?? key;
+	if (params) {
+		for (const [k, v] of Object.entries(params)) {
+			str = str.replaceAll(`{${k}}`, v);
+		}
+	}
+	return str;
+}
+
+/**
+ * Pluralize a digest event label.
+ * String format: "singular|plural" (en/vi) or "1|2-4|5+" (ru).
+ */
+export function pluralize(
+	locale: Locale,
+	key: string,
+	count: number,
+): string {
+	const raw = t(locale, key);
+	const parts = raw.split("|");
+	if (locale === "ru" && parts.length === 3) {
+		const mod10 = count % 10;
+		const mod100 = count % 100;
+		if (mod10 === 1 && mod100 !== 11) return `${count} ${parts[0]}`;
+		if (mod10 >= 2 && mod10 <= 4 && (mod100 < 10 || mod100 >= 20))
+			return `${count} ${parts[1]}`;
+		return `${count} ${parts[2]}`;
+	}
+	return `${count} ${count === 1 ? (parts[0] ?? raw) : (parts[1] ?? parts[0] ?? raw)}`;
+}
+
+export function contactLines(
+	contacts: {
+		telegram?: string;
+		whatsapp?: string;
+		facebook?: string;
+		phone?: string;
+	},
+	locale: Locale,
+): string {
+	const lines: string[] = [];
+	if (contacts.telegram)
+		lines.push(t(locale, "shared.contactTelegram", { handle: contacts.telegram }));
+	if (contacts.whatsapp)
+		lines.push(t(locale, "shared.contactWhatsapp", { number: contacts.whatsapp }));
+	if (contacts.facebook)
+		lines.push(t(locale, "shared.contactFacebook", { profile: contacts.facebook }));
+	if (contacts.phone)
+		lines.push(t(locale, "shared.contactPhone", { number: contacts.phone }));
+	return lines.length > 0 ? lines.join("\n") : t(locale, "shared.contactNone");
+}

--- a/convex/emailTemplates/index.ts
+++ b/convex/emailTemplates/index.ts
@@ -1,9 +1,11 @@
+export type { Locale } from "./i18n";
 export type {
-  ContactInfo,
-  DigestNotification,
-  DigestItemSummary,
+	ContactInfo,
+	DigestNotification,
+	DigestItemSummary,
 } from "./_shared";
 export { WelcomeEmail } from "./welcome";
+export type { WelcomeEmailProps } from "./welcome";
 export { LeaseApprovedEmail } from "./leaseApproved";
 export type { LeaseApprovedData } from "./leaseApproved";
 export { MeetupConfirmedEmail } from "./meetupConfirmed";

--- a/convex/emailTemplates/itemAvailable.tsx
+++ b/convex/emailTemplates/itemAvailable.tsx
@@ -1,41 +1,44 @@
 import { Text } from "@react-email/components";
 import * as React from "react";
 import { Callout, EmailButton, SharityEmail, appUrl, COLORS } from "./_shared";
+import { t } from "./i18n";
+import type { Locale } from "./i18n";
 
 export interface ItemAvailableData {
-  recipientName: string;
-  itemName: string;
-  itemId: string;
+	recipientName: string;
+	itemName: string;
+	itemId: string;
+	locale: Locale;
 }
 
 export function ItemAvailableEmail(data: ItemAvailableData) {
-  const itemUrl = appUrl(`/item/${data.itemId}`);
+	const itemUrl = appUrl(`/item/${data.itemId}`);
 
-  return (
-    <SharityEmail preview={`"${data.itemName}" is available again!`}>
-      <Text
-        style={{
-          fontSize: "22px",
-          fontWeight: "700",
-          color: COLORS.heading,
-          margin: "0 0 12px",
-        }}
-      >
-        Item Available!
-      </Text>
-      <Text style={{ color: COLORS.body, fontSize: "15px", margin: "0 0 8px" }}>
-        Hi {data.recipientName},
-      </Text>
-      <Text
-        style={{ color: COLORS.body, fontSize: "15px", margin: "0 0 16px" }}
-      >
-        Great news — <strong>{data.itemName}</strong>, the item you were
-        watching, is available again.
-      </Text>
-      <Callout>
-        Items can be claimed quickly. Request it now before someone else does!
-      </Callout>
-      <EmailButton href={itemUrl}>Request It Now</EmailButton>
-    </SharityEmail>
-  );
+	return (
+		<SharityEmail
+			preview={t(data.locale, "itemAvailable.preview", { itemName: data.itemName })}
+			locale={data.locale}
+		>
+			<Text
+				style={{
+					fontSize: "22px",
+					fontWeight: "700",
+					color: COLORS.heading,
+					margin: "0 0 12px",
+				}}
+			>
+				{t(data.locale, "itemAvailable.heading")}
+			</Text>
+			<Text style={{ color: COLORS.body, fontSize: "15px", margin: "0 0 8px" }}>
+				{t(data.locale, "itemAvailable.greeting", { recipientName: data.recipientName })}
+			</Text>
+			<Text
+				style={{ color: COLORS.body, fontSize: "15px", margin: "0 0 16px" }}
+			>
+				{t(data.locale, "itemAvailable.body", { itemName: data.itemName })}
+			</Text>
+			<Callout>{t(data.locale, "itemAvailable.callout")}</Callout>
+			<EmailButton href={itemUrl}>{t(data.locale, "itemAvailable.cta")}</EmailButton>
+		</SharityEmail>
+	);
 }

--- a/convex/emailTemplates/leaseApproved.tsx
+++ b/convex/emailTemplates/leaseApproved.tsx
@@ -1,59 +1,62 @@
 import { Text } from "@react-email/components";
 import * as React from "react";
 import {
-  Callout,
-  EmailButton,
-  SharityEmail,
-  appUrl,
-  formatDate,
-  COLORS,
+	Callout,
+	EmailButton,
+	SharityEmail,
+	appUrl,
+	COLORS,
 } from "./_shared";
+import { t, formatDateLocalized } from "./i18n";
+import type { Locale } from "./i18n";
 
 export interface LeaseApprovedData {
-  borrowerName: string;
-  itemName: string;
-  startDate: number;
-  endDate: number;
-  claimId: string;
-  itemId: string;
+	borrowerName: string;
+	itemName: string;
+	startDate: number;
+	endDate: number;
+	claimId: string;
+	itemId: string;
+	locale: Locale;
 }
 
 export function LeaseApprovedEmail(data: LeaseApprovedData) {
-  const dateRange = `${formatDate(data.startDate)} – ${formatDate(data.endDate)}`;
-  const itemUrl = appUrl(`/item/${data.itemId}`);
+	const dateRange = `${formatDateLocalized(data.startDate, data.locale)} – ${formatDateLocalized(data.endDate, data.locale)}`;
+	const itemUrl = appUrl(`/item/${data.itemId}`);
 
-  return (
-    <SharityEmail preview={`Your request for "${data.itemName}" was approved`}>
-      <Text
-        style={{
-          fontSize: "22px",
-          fontWeight: "700",
-          color: COLORS.heading,
-          margin: "0 0 12px",
-        }}
-      >
-        Request Approved
-      </Text>
-      <Text style={{ color: COLORS.body, fontSize: "15px", margin: "0 0 8px" }}>
-        Hi {data.borrowerName},
-      </Text>
-      <Text
-        style={{ color: COLORS.body, fontSize: "15px", margin: "0 0 16px" }}
-      >
-        Your request for <strong>{data.itemName}</strong> has been approved for{" "}
-        <strong>{dateRange}</strong>.
-      </Text>
-      <Callout>
-        <strong>Next step:</strong> Propose a pickup window so you and the owner
-        can coordinate the handover.
-      </Callout>
-      <EmailButton href={itemUrl}>Propose Pickup Time</EmailButton>
-      <Text
-        style={{ color: COLORS.muted, fontSize: "13px", margin: "12px 0 0" }}
-      >
-        If you can no longer make it, you can cancel your request on the item
-        page.
-      </Text>
-    </SharityEmail>
-  );
+	return (
+		<SharityEmail
+			preview={t(data.locale, "leaseApproved.preview", { itemName: data.itemName })}
+			locale={data.locale}
+		>
+			<Text
+				style={{
+					fontSize: "22px",
+					fontWeight: "700",
+					color: COLORS.heading,
+					margin: "0 0 12px",
+				}}
+			>
+				{t(data.locale, "leaseApproved.heading")}
+			</Text>
+			<Text style={{ color: COLORS.body, fontSize: "15px", margin: "0 0 8px" }}>
+				{t(data.locale, "leaseApproved.greeting", { borrowerName: data.borrowerName })}
+			</Text>
+			<Text
+				style={{ color: COLORS.body, fontSize: "15px", margin: "0 0 16px" }}
+			>
+				{t(data.locale, "leaseApproved.body", {
+					itemName: data.itemName,
+					dateRange,
+				})}
+			</Text>
+			<Callout>{t(data.locale, "leaseApproved.callout")}</Callout>
+			<EmailButton href={itemUrl}>{t(data.locale, "leaseApproved.cta")}</EmailButton>
+			<Text
+				style={{ color: COLORS.muted, fontSize: "13px", margin: "12px 0 0" }}
+			>
+				{t(data.locale, "leaseApproved.footer")}
+			</Text>
+		</SharityEmail>
+	);
 }

--- a/convex/emailTemplates/meetupConfirmed.tsx
+++ b/convex/emailTemplates/meetupConfirmed.tsx
@@ -1,93 +1,89 @@
 import { Section, Text } from "@react-email/components";
 import * as React from "react";
 import {
-  Callout,
-  EmailButton,
-  SharityEmail,
-  appUrl,
-  contactLines,
-  formatWindow,
-  COLORS,
+	Callout,
+	EmailButton,
+	SharityEmail,
+	appUrl,
+	COLORS,
 } from "./_shared";
+import { t, formatWindowLocalized, contactLines } from "./i18n";
+import type { Locale } from "./i18n";
 import type { ContactInfo } from "./_shared";
 
 export interface MeetupConfirmedData {
-  recipientName: string;
-  counterpartyName: string;
-  counterpartyContacts: ContactInfo;
-  itemName: string;
-  windowStartAt: number;
-  windowEndAt: number;
-  itemId: string;
-  meetupType: "pickup" | "return";
+	recipientName: string;
+	counterpartyName: string;
+	counterpartyContacts: ContactInfo;
+	itemName: string;
+	windowStartAt: number;
+	windowEndAt: number;
+	itemId: string;
+	meetupType: "pickup" | "return";
+	locale: Locale;
 }
 
 export function MeetupConfirmedEmail(data: MeetupConfirmedData) {
-  const windowStr = formatWindow(data.windowStartAt, data.windowEndAt);
-  const verb = data.meetupType === "pickup" ? "pick up" : "return";
-  const afterMeetup = data.meetupType === "pickup" ? "picked up" : "returned";
-  const itemUrl = appUrl(`/item/${data.itemId}`);
-  const contacts = contactLines(data.counterpartyContacts);
+	const windowStr = formatWindowLocalized(data.windowStartAt, data.windowEndAt, data.locale);
+	const itemUrl = appUrl(`/item/${data.itemId}`);
+	const contacts = contactLines(data.counterpartyContacts, data.locale);
+	const typeKey = data.meetupType === "pickup" ? "pickup" : "return";
 
-  return (
-    <SharityEmail preview={`Meetup confirmed for "${data.itemName}"`}>
-      <Text
-        style={{
-          fontSize: "22px",
-          fontWeight: "700",
-          color: COLORS.heading,
-          margin: "0 0 12px",
-        }}
-      >
-        Meetup Confirmed
-      </Text>
-      <Text style={{ color: COLORS.body, fontSize: "15px", margin: "0 0 8px" }}>
-        Hi {data.recipientName},
-      </Text>
-      <Text
-        style={{ color: COLORS.body, fontSize: "15px", margin: "0 0 16px" }}
-      >
-        Your meetup to{" "}
-        <strong>
-          {verb} &ldquo;{data.itemName}&rdquo;
-        </strong>{" "}
-        is confirmed:
-      </Text>
-      <Section
-        style={{
-          backgroundColor: COLORS.card,
-          borderRadius: "6px",
-          padding: "12px 16px",
-          margin: "0 0 16px",
-          textAlign: "center" as const,
-        }}
-      >
-        <Text
-          style={{
-            fontSize: "16px",
-            fontWeight: "700",
-            color: COLORS.heading,
-            margin: "0",
-          }}
-        >
-          {windowStr}
-        </Text>
-      </Section>
-      <Text style={{ color: COLORS.body, fontSize: "14px", margin: "0 0 4px" }}>
-        <strong>Who to meet:</strong> {data.counterpartyName}
-      </Text>
-      <Text
-        style={{ color: COLORS.body, fontSize: "14px", margin: "0 0 16px" }}
-      >
-        <strong>Their contact info:</strong>
-        <br />
-        {contacts}
-      </Text>
-      <EmailButton href={itemUrl}>View Item</EmailButton>
-      <Callout>
-        After the meetup, mark the item as {afterMeetup} on the item page to
-        complete the handover.
-      </Callout>
-    </SharityEmail>
-  );
+	return (
+		<SharityEmail
+			preview={t(data.locale, "meetupConfirmed.preview", { itemName: data.itemName })}
+			locale={data.locale}
+		>
+			<Text
+				style={{
+					fontSize: "22px",
+					fontWeight: "700",
+					color: COLORS.heading,
+					margin: "0 0 12px",
+				}}
+			>
+				{t(data.locale, "meetupConfirmed.heading")}
+			</Text>
+			<Text style={{ color: COLORS.body, fontSize: "15px", margin: "0 0 8px" }}>
+				{t(data.locale, "meetupConfirmed.greeting", { recipientName: data.recipientName })}
+			</Text>
+			<Text
+				style={{ color: COLORS.body, fontSize: "15px", margin: "0 0 16px" }}
+			>
+				{t(data.locale, `meetupConfirmed.body.${typeKey}`, { itemName: data.itemName })}
+			</Text>
+			<Section
+				style={{
+					backgroundColor: COLORS.card,
+					borderRadius: "6px",
+					padding: "12px 16px",
+					margin: "0 0 16px",
+					textAlign: "center" as const,
+				}}
+			>
+				<Text
+					style={{
+						fontSize: "16px",
+						fontWeight: "700",
+						color: COLORS.heading,
+						margin: "0",
+					}}
+				>
+					{windowStr}
+				</Text>
+			</Section>
+			<Text style={{ color: COLORS.body, fontSize: "14px", margin: "0 0 4px" }}>
+				{t(data.locale, "meetupConfirmed.whoToMeet", { name: data.counterpartyName })}
+			</Text>
+			<Text
+				style={{ color: COLORS.body, fontSize: "14px", margin: "0 0 16px" }}
+			>
+				{t(data.locale, "meetupConfirmed.contactInfo")}
+				<br />
+				{contacts}
+			</Text>
+			<EmailButton href={itemUrl}>{t(data.locale, "meetupConfirmed.cta")}</EmailButton>
+			<Callout>{t(data.locale, `meetupConfirmed.callout.${typeKey}`)}</Callout>
+		</SharityEmail>
+	);
 }

--- a/convex/emailTemplates/meetupProposed.tsx
+++ b/convex/emailTemplates/meetupProposed.tsx
@@ -1,82 +1,84 @@
 import { Section, Text } from "@react-email/components";
 import * as React from "react";
 import {
-  Callout,
-  EmailButton,
-  SharityEmail,
-  appUrl,
-  formatWindow,
-  COLORS,
+	Callout,
+	EmailButton,
+	SharityEmail,
+	appUrl,
+	COLORS,
 } from "./_shared";
+import { t, formatWindowLocalized } from "./i18n";
+import type { Locale } from "./i18n";
 
 export interface MeetupProposedData {
-  recipientName: string;
-  proposerName: string;
-  itemName: string;
-  windowStartAt: number;
-  windowEndAt: number;
-  itemId: string;
-  meetupType: "pickup" | "return";
+	recipientName: string;
+	proposerName: string;
+	itemName: string;
+	windowStartAt: number;
+	windowEndAt: number;
+	itemId: string;
+	meetupType: "pickup" | "return";
+	locale: Locale;
 }
 
 export function MeetupProposedEmail(data: MeetupProposedData) {
-  const windowStr = formatWindow(data.windowStartAt, data.windowEndAt);
-  const verb = data.meetupType === "pickup" ? "pick up" : "return";
-  const itemUrl = appUrl(`/item/${data.itemId}`);
+	const windowStr = formatWindowLocalized(data.windowStartAt, data.windowEndAt, data.locale);
+	const itemUrl = appUrl(`/item/${data.itemId}`);
+	const typeKey = data.meetupType === "pickup" ? "pickup" : "return";
 
-  return (
-    <SharityEmail
-      preview={`${data.meetupType === "pickup" ? "Pickup" : "Return"} time proposed for "${data.itemName}"`}
-    >
-      <Text
-        style={{
-          fontSize: "22px",
-          fontWeight: "700",
-          color: COLORS.heading,
-          margin: "0 0 12px",
-        }}
-      >
-        {data.meetupType === "pickup" ? "Pickup" : "Return"} Time Proposed
-      </Text>
-      <Text style={{ color: COLORS.body, fontSize: "15px", margin: "0 0 8px" }}>
-        Hi {data.recipientName},
-      </Text>
-      <Text
-        style={{ color: COLORS.body, fontSize: "15px", margin: "0 0 16px" }}
-      >
-        <strong>{data.proposerName}</strong> proposed a time to {verb}{" "}
-        <strong>&ldquo;{data.itemName}&rdquo;</strong>:
-      </Text>
-      <Section
-        style={{
-          backgroundColor: COLORS.card,
-          borderRadius: "6px",
-          padding: "12px 16px",
-          margin: "0 0 16px",
-          textAlign: "center" as const,
-        }}
-      >
-        <Text
-          style={{
-            fontSize: "16px",
-            fontWeight: "700",
-            color: COLORS.heading,
-            margin: "0",
-          }}
-        >
-          {windowStr}
-        </Text>
-      </Section>
-      <Callout>
-        Review and approve this time so both parties can confirm the meetup.
-      </Callout>
-      <EmailButton href={itemUrl}>Review &amp; Approve</EmailButton>
-      <Text
-        style={{ color: COLORS.muted, fontSize: "13px", margin: "12px 0 0" }}
-      >
-        If this time doesn&apos;t work, you can propose a different window on
-        the item page.
-      </Text>
-    </SharityEmail>
-  );
+	return (
+		<SharityEmail
+			preview={t(data.locale, `meetupProposed.preview.${typeKey}`, { itemName: data.itemName })}
+			locale={data.locale}
+		>
+			<Text
+				style={{
+					fontSize: "22px",
+					fontWeight: "700",
+					color: COLORS.heading,
+					margin: "0 0 12px",
+				}}
+			>
+				{t(data.locale, `meetupProposed.heading.${typeKey}`)}
+			</Text>
+			<Text style={{ color: COLORS.body, fontSize: "15px", margin: "0 0 8px" }}>
+				{t(data.locale, "meetupProposed.greeting", { recipientName: data.recipientName })}
+			</Text>
+			<Text
+				style={{ color: COLORS.body, fontSize: "15px", margin: "0 0 16px" }}
+			>
+				{t(data.locale, `meetupProposed.body.${typeKey}`, {
+					proposerName: data.proposerName,
+					itemName: data.itemName,
+				})}
+			</Text>
+			<Section
+				style={{
+					backgroundColor: COLORS.card,
+					borderRadius: "6px",
+					padding: "12px 16px",
+					margin: "0 0 16px",
+					textAlign: "center" as const,
+				}}
+			>
+				<Text
+					style={{
+						fontSize: "16px",
+						fontWeight: "700",
+						color: COLORS.heading,
+						margin: "0",
+					}}
+				>
+					{windowStr}
+				</Text>
+			</Section>
+			<Callout>{t(data.locale, "meetupProposed.callout")}</Callout>
+			<EmailButton href={itemUrl}>{t(data.locale, "meetupProposed.cta")}</EmailButton>
+			<Text
+				style={{ color: COLORS.muted, fontSize: "13px", margin: "12px 0 0" }}
+			>
+				{t(data.locale, "meetupProposed.footer")}
+			</Text>
+		</SharityEmail>
+	);
 }

--- a/convex/emailTemplates/newRequest.tsx
+++ b/convex/emailTemplates/newRequest.tsx
@@ -1,59 +1,63 @@
 import { Text } from "@react-email/components";
 import * as React from "react";
 import {
-  Callout,
-  EmailButton,
-  SharityEmail,
-  appUrl,
-  formatDate,
-  COLORS,
+	Callout,
+	EmailButton,
+	SharityEmail,
+	appUrl,
+	COLORS,
 } from "./_shared";
+import { t, formatDateLocalized } from "./i18n";
+import type { Locale } from "./i18n";
 
 export interface NewRequestData {
-  ownerName: string;
-  borrowerName: string;
-  itemName: string;
-  startDate: number;
-  endDate: number;
-  itemId: string;
+	ownerName: string;
+	borrowerName: string;
+	itemName: string;
+	startDate: number;
+	endDate: number;
+	itemId: string;
+	locale: Locale;
 }
 
 export function NewRequestEmail(data: NewRequestData) {
-  const dateRange = `${formatDate(data.startDate)} – ${formatDate(data.endDate)}`;
-  const itemUrl = appUrl(`/item/${data.itemId}`);
+	const dateRange = `${formatDateLocalized(data.startDate, data.locale)} – ${formatDateLocalized(data.endDate, data.locale)}`;
+	const itemUrl = appUrl(`/item/${data.itemId}`);
 
-  return (
-    <SharityEmail preview={`New request for "${data.itemName}"`}>
-      <Text
-        style={{
-          fontSize: "22px",
-          fontWeight: "700",
-          color: COLORS.heading,
-          margin: "0 0 12px",
-        }}
-      >
-        New Borrow Request
-      </Text>
-      <Text style={{ color: COLORS.body, fontSize: "15px", margin: "0 0 8px" }}>
-        Hi {data.ownerName},
-      </Text>
-      <Text
-        style={{ color: COLORS.body, fontSize: "15px", margin: "0 0 16px" }}
-      >
-        <strong>{data.borrowerName}</strong> wants to borrow your item{" "}
-        <strong>{data.itemName}</strong> for <strong>{dateRange}</strong>.
-      </Text>
-      <Callout>
-        Review the request and approve or decline it so the borrower can plan
-        ahead.
-      </Callout>
-      <EmailButton href={itemUrl}>Review Request</EmailButton>
-      <Text
-        style={{ color: COLORS.muted, fontSize: "13px", margin: "12px 0 0" }}
-      >
-        You have up to the start date to respond. Unanswered requests expire
-        automatically.
-      </Text>
-    </SharityEmail>
-  );
+	return (
+		<SharityEmail
+			preview={t(data.locale, "newRequest.preview", { itemName: data.itemName })}
+			locale={data.locale}
+		>
+			<Text
+				style={{
+					fontSize: "22px",
+					fontWeight: "700",
+					color: COLORS.heading,
+					margin: "0 0 12px",
+				}}
+			>
+				{t(data.locale, "newRequest.heading")}
+			</Text>
+			<Text style={{ color: COLORS.body, fontSize: "15px", margin: "0 0 8px" }}>
+				{t(data.locale, "newRequest.greeting", { ownerName: data.ownerName })}
+			</Text>
+			<Text
+				style={{ color: COLORS.body, fontSize: "15px", margin: "0 0 16px" }}
+			>
+				{t(data.locale, "newRequest.body", {
+					borrowerName: data.borrowerName,
+					itemName: data.itemName,
+					dateRange,
+				})}
+			</Text>
+			<Callout>{t(data.locale, "newRequest.callout")}</Callout>
+			<EmailButton href={itemUrl}>{t(data.locale, "newRequest.cta")}</EmailButton>
+			<Text
+				style={{ color: COLORS.muted, fontSize: "13px", margin: "12px 0 0" }}
+			>
+				{t(data.locale, "newRequest.footer")}
+			</Text>
+		</SharityEmail>
+	);
 }

--- a/convex/emailTemplates/overdueAlert.tsx
+++ b/convex/emailTemplates/overdueAlert.tsx
@@ -1,107 +1,109 @@
 import { Section, Text } from "@react-email/components";
 import * as React from "react";
 import {
-  EmailButton,
-  SharityEmail,
-  appUrl,
-  contactLines,
-  formatDate,
-  COLORS,
+	EmailButton,
+	SharityEmail,
+	appUrl,
+	COLORS,
 } from "./_shared";
+import { t, formatDateLocalized, contactLines } from "./i18n";
+import type { Locale } from "./i18n";
 import type { ContactInfo } from "./_shared";
 
 export interface OverdueAlertData {
-  recipientName: string;
-  itemName: string;
-  originalEndDate: number;
-  counterpartyName: string;
-  counterpartyContacts: ContactInfo;
-  itemId: string;
-  role: "owner" | "borrower";
+	recipientName: string;
+	itemName: string;
+	originalEndDate: number;
+	counterpartyName: string;
+	counterpartyContacts: ContactInfo;
+	itemId: string;
+	role: "owner" | "borrower";
+	locale: Locale;
 }
 
 export function OverdueAlertEmail(data: OverdueAlertData) {
-  const dueDateStr = formatDate(data.originalEndDate);
-  const itemUrl = appUrl(`/item/${data.itemId}`);
-  const contacts = contactLines(data.counterpartyContacts);
+	const dueDateStr = formatDateLocalized(data.originalEndDate, data.locale);
+	const itemUrl = appUrl(`/item/${data.itemId}`);
+	const contacts = contactLines(data.counterpartyContacts, data.locale);
 
-  const headline =
-    data.role === "owner"
-      ? `"${data.itemName}" has not been returned`
-      : `You have an overdue item: "${data.itemName}"`;
+	const headline = t(data.locale, `overdueAlert.headline.${data.role}`, {
+		itemName: data.itemName,
+	});
+	const body = t(data.locale, `overdueAlert.body.${data.role}`, {
+		itemName: data.itemName,
+		dueDate: dueDateStr,
+	});
 
-  const body =
-    data.role === "owner"
-      ? `The return window has passed (due ${dueDateStr}). Please contact the borrower to arrange the return.`
-      : `Your borrow of ${data.itemName} was due back on ${dueDateStr}. Please contact the owner to arrange the return as soon as possible.`;
-
-  return (
-    <SharityEmail preview={`Action needed: "${data.itemName}" is overdue`}>
-      <Section
-        style={{
-          backgroundColor: COLORS.danger,
-          borderRadius: "6px",
-          padding: "8px 16px",
-          margin: "0 0 16px",
-        }}
-      >
-        <Text
-          style={{
-            color: COLORS.dangerText,
-            fontSize: "13px",
-            fontWeight: "700",
-            margin: "0",
-            textTransform: "uppercase" as const,
-            letterSpacing: "0.05em",
-          }}
-        >
-          Overdue Item
-        </Text>
-      </Section>
-      <Text
-        style={{
-          fontSize: "20px",
-          fontWeight: "700",
-          color: COLORS.heading,
-          margin: "0 0 12px",
-        }}
-      >
-        {headline}
-      </Text>
-      <Text style={{ color: COLORS.body, fontSize: "15px", margin: "0 0 8px" }}>
-        Hi {data.recipientName},
-      </Text>
-      <Text
-        style={{ color: COLORS.body, fontSize: "15px", margin: "0 0 16px" }}
-      >
-        {body}
-      </Text>
-      <Text style={{ color: COLORS.body, fontSize: "14px", margin: "0 0 4px" }}>
-        <strong>Contact {data.counterpartyName}:</strong>
-      </Text>
-      <Text
-        style={{
-          color: COLORS.body,
-          fontSize: "14px",
-          margin: "0 0 16px",
-          whiteSpace: "pre-line" as const,
-        }}
-      >
-        {contacts}
-      </Text>
-      <EmailButton href={itemUrl}>View Item</EmailButton>
-      <Section
-        style={{
-          backgroundColor: COLORS.card,
-          borderRadius: "6px",
-          padding: "12px 16px",
-          margin: "16px 0 0",
-        }}
-      >
-        <Text style={{ color: COLORS.body, fontSize: "14px", margin: "0" }}>
-          If you cannot reach the other party, please contact Sharity support.
-        </Text>
-      </Section>
-    </SharityEmail>
-  );
+	return (
+		<SharityEmail
+			preview={t(data.locale, "overdueAlert.preview", { itemName: data.itemName })}
+			locale={data.locale}
+		>
+			<Section
+				style={{
+					backgroundColor: COLORS.danger,
+					borderRadius: "6px",
+					padding: "8px 16px",
+					margin: "0 0 16px",
+				}}
+			>
+				<Text
+					style={{
+						color: COLORS.dangerText,
+						fontSize: "13px",
+						fontWeight: "700",
+						margin: "0",
+						textTransform: "uppercase" as const,
+						letterSpacing: "0.05em",
+					}}
+				>
+					{t(data.locale, "overdueAlert.badge")}
+				</Text>
+			</Section>
+			<Text
+				style={{
+					fontSize: "20px",
+					fontWeight: "700",
+					color: COLORS.heading,
+					margin: "0 0 12px",
+				}}
+			>
+				{headline}
+			</Text>
+			<Text style={{ color: COLORS.body, fontSize: "15px", margin: "0 0 8px" }}>
+				{t(data.locale, "overdueAlert.greeting", { recipientName: data.recipientName })}
+			</Text>
+			<Text
+				style={{ color: COLORS.body, fontSize: "15px", margin: "0 0 16px" }}
+			>
+				{body}
+			</Text>
+			<Text style={{ color: COLORS.body, fontSize: "14px", margin: "0 0 4px" }}>
+				{t(data.locale, "overdueAlert.contactLabel", { counterpartyName: data.counterpartyName })}
+			</Text>
+			<Text
+				style={{
+					color: COLORS.body,
+					fontSize: "14px",
+					margin: "0 0 16px",
+					whiteSpace: "pre-line" as const,
+				}}
+			>
+				{contacts}
+			</Text>
+			<EmailButton href={itemUrl}>{t(data.locale, "overdueAlert.cta")}</EmailButton>
+			<Section
+				style={{
+					backgroundColor: COLORS.card,
+					borderRadius: "6px",
+					padding: "12px 16px",
+					margin: "16px 0 0",
+				}}
+			>
+				<Text style={{ color: COLORS.body, fontSize: "14px", margin: "0" }}>
+					{t(data.locale, "overdueAlert.support")}
+				</Text>
+			</Section>
+		</SharityEmail>
+	);
 }

--- a/convex/emailTemplates/requestRejected.tsx
+++ b/convex/emailTemplates/requestRejected.tsx
@@ -1,52 +1,54 @@
 import { Text } from "@react-email/components";
 import * as React from "react";
 import {
-  Callout,
-  EmailButton,
-  SharityEmail,
-  appUrl,
-  formatDate,
-  COLORS,
+	Callout,
+	EmailButton,
+	SharityEmail,
+	appUrl,
+	COLORS,
 } from "./_shared";
+import { t, formatDateLocalized } from "./i18n";
+import type { Locale } from "./i18n";
 
 export interface RequestRejectedData {
-  borrowerName: string;
-  itemName: string;
-  startDate: number;
-  endDate: number;
+	borrowerName: string;
+	itemName: string;
+	startDate: number;
+	endDate: number;
+	locale: Locale;
 }
 
 export function RequestRejectedEmail(data: RequestRejectedData) {
-  const dateRange = `${formatDate(data.startDate)} – ${formatDate(data.endDate)}`;
+	const dateRange = `${formatDateLocalized(data.startDate, data.locale)} – ${formatDateLocalized(data.endDate, data.locale)}`;
 
-  return (
-    <SharityEmail
-      preview={`Your request for "${data.itemName}" was not approved`}
-    >
-      <Text
-        style={{
-          fontSize: "22px",
-          fontWeight: "700",
-          color: COLORS.heading,
-          margin: "0 0 12px",
-        }}
-      >
-        Request Not Approved
-      </Text>
-      <Text style={{ color: COLORS.body, fontSize: "15px", margin: "0 0 8px" }}>
-        Hi {data.borrowerName},
-      </Text>
-      <Text
-        style={{ color: COLORS.body, fontSize: "15px", margin: "0 0 16px" }}
-      >
-        Unfortunately, the owner declined your request for{" "}
-        <strong>{data.itemName}</strong> ({dateRange}).
-      </Text>
-      <Callout>
-        Don&apos;t worry — there are plenty of other items available on Sharity.
-        Browse the catalogue to find what you need.
-      </Callout>
-      <EmailButton href={appUrl("/")}>Browse Other Items</EmailButton>
-    </SharityEmail>
-  );
+	return (
+		<SharityEmail
+			preview={t(data.locale, "requestRejected.preview", { itemName: data.itemName })}
+			locale={data.locale}
+		>
+			<Text
+				style={{
+					fontSize: "22px",
+					fontWeight: "700",
+					color: COLORS.heading,
+					margin: "0 0 12px",
+				}}
+			>
+				{t(data.locale, "requestRejected.heading")}
+			</Text>
+			<Text style={{ color: COLORS.body, fontSize: "15px", margin: "0 0 8px" }}>
+				{t(data.locale, "requestRejected.greeting", { borrowerName: data.borrowerName })}
+			</Text>
+			<Text
+				style={{ color: COLORS.body, fontSize: "15px", margin: "0 0 16px" }}
+			>
+				{t(data.locale, "requestRejected.body", {
+					itemName: data.itemName,
+					dateRange,
+				})}
+			</Text>
+			<Callout>{t(data.locale, "requestRejected.callout")}</Callout>
+			<EmailButton href={appUrl("/")}>{t(data.locale, "requestRejected.cta")}</EmailButton>
+		</SharityEmail>
+	);
 }

--- a/convex/emailTemplates/welcome.tsx
+++ b/convex/emailTemplates/welcome.tsx
@@ -1,51 +1,48 @@
-import { Link, Section, Text } from "@react-email/components";
+import { Section, Text } from "@react-email/components";
 import * as React from "react";
 import { Callout, EmailButton, SharityEmail, appUrl, COLORS } from "./_shared";
+import { t } from "./i18n";
+import type { Locale } from "./i18n";
 
-interface WelcomeEmailProps {
-  name: string;
+export interface WelcomeEmailProps {
+	name: string;
+	locale: Locale;
 }
 
-export function WelcomeEmail({ name }: WelcomeEmailProps) {
-  return (
-    <SharityEmail preview={`Welcome to Sharity, ${name}!`}>
-      <Text
-        style={{
-          fontSize: "22px",
-          fontWeight: "700",
-          color: COLORS.heading,
-          margin: "0 0 8px",
-        }}
-      >
-        Hey {name}!
-      </Text>
-      <Text
-        style={{ color: COLORS.body, fontSize: "15px", margin: "0 0 16px" }}
-      >
-        Welcome to <strong>Sharity</strong> — a community where neighbours share
-        things they own but rarely use.
-      </Text>
-      <Text style={{ color: COLORS.body, fontSize: "14px", margin: "0 0 4px" }}>
-        Here&apos;s what you can do:
-      </Text>
-      <Section style={{ margin: "8px 0 16px", paddingLeft: "16px" }}>
-        <Text style={{ color: COLORS.body, fontSize: "14px", margin: "4px 0" }}>
-          • <strong>Browse items</strong> — find something you need without
-          buying it
-        </Text>
-        <Text style={{ color: COLORS.body, fontSize: "14px", margin: "4px 0" }}>
-          • <strong>List your stuff</strong> — put idle items to good use
-        </Text>
-        <Text style={{ color: COLORS.body, fontSize: "14px", margin: "4px 0" }}>
-          • <strong>Request a loan</strong> — pick dates, get approved, arrange
-          pickup
-        </Text>
-      </Section>
-      <EmailButton href={appUrl("/")}>Explore Items</EmailButton>
-      <Callout>
-        <strong>No money changes hands.</strong> Sharity runs on trust and
-        community goodwill.
-      </Callout>
-    </SharityEmail>
-  );
+export function WelcomeEmail({ name, locale }: WelcomeEmailProps) {
+	return (
+		<SharityEmail preview={t(locale, "welcome.preview", { name })} locale={locale}>
+			<Text
+				style={{
+					fontSize: "22px",
+					fontWeight: "700",
+					color: COLORS.heading,
+					margin: "0 0 8px",
+				}}
+			>
+				{t(locale, "welcome.heading", { name })}
+			</Text>
+			<Text
+				style={{ color: COLORS.body, fontSize: "15px", margin: "0 0 16px" }}
+			>
+				{t(locale, "welcome.intro")}
+			</Text>
+			<Text style={{ color: COLORS.body, fontSize: "14px", margin: "0 0 4px" }}>
+				{t(locale, "welcome.canDoIntro")}
+			</Text>
+			<Section style={{ margin: "8px 0 16px", paddingLeft: "16px" }}>
+				<Text style={{ color: COLORS.body, fontSize: "14px", margin: "4px 0" }}>
+					• {t(locale, "welcome.bullet.browse")}
+				</Text>
+				<Text style={{ color: COLORS.body, fontSize: "14px", margin: "4px 0" }}>
+					• {t(locale, "welcome.bullet.list")}
+				</Text>
+				<Text style={{ color: COLORS.body, fontSize: "14px", margin: "4px 0" }}>
+					• {t(locale, "welcome.bullet.request")}
+				</Text>
+			</Section>
+			<EmailButton href={appUrl("/")}>{t(locale, "welcome.cta")}</EmailButton>
+			<Callout>{t(locale, "welcome.callout")}</Callout>
+		</SharityEmail>
+	);
 }

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -53,6 +53,7 @@ http.route({
           clerkId: id,
           email,
           name: name ?? "there",
+          locale: "en",
         });
       }
     }

--- a/convex/items.ts
+++ b/convex/items.ts
@@ -932,6 +932,7 @@ export const requestItem = mutation({
       await ctx.scheduler.runAfter(0, internal.emailSend.sendNewRequest, {
         claimId,
         ownerEmail: owner.email,
+        locale: owner.profile.locale,
         data: {
           ownerName: owner.name,
           borrowerName: borrowerProfile?.name ?? "Someone",
@@ -1028,6 +1029,7 @@ export const approveClaim = mutation({
       await ctx.scheduler.runAfter(0, internal.emailSend.sendLeaseApproved, {
         claimId: args.claimId,
         borrowerEmail: borrower.email,
+        locale: borrower.profile.locale,
         data: {
           borrowerName: borrower.name,
           itemName: item.name,
@@ -1193,6 +1195,7 @@ export const proposePickupWindow = mutation({
         claimId: args.claimId,
         meetupType: "pickup",
         recipientEmail: recipient.email,
+        locale: recipient.profile.locale,
         data: {
           recipientName: recipient.name,
           proposerName: proposerProfile?.name ?? "The other party",
@@ -1323,6 +1326,7 @@ export const proposeReturnWindow = mutation({
         claimId: args.claimId,
         meetupType: "return",
         recipientEmail: returnRecipient.email,
+        locale: returnRecipient.profile.locale,
         data: {
           recipientName: returnRecipient.name,
           proposerName: returnProposerProfile?.name ?? "The other party",
@@ -1436,6 +1440,8 @@ export const approvePickupWindow = mutation({
         meetupType: "pickup",
         recipient1Email: proposer.email,
         recipient2Email: approver.email,
+        locale1: proposer.profile.locale,
+        locale2: approver.profile.locale,
         data1: {
           recipientName: proposer.name,
           counterpartyName: approver.name,
@@ -1572,6 +1578,8 @@ export const approveReturnWindow = mutation({
         meetupType: "return",
         recipient1Email: proposer.email,
         recipient2Email: approver.email,
+        locale1: proposer.profile.locale,
+        locale2: approver.profile.locale,
         data1: {
           recipientName: proposer.name,
           counterpartyName: approver.name,
@@ -1969,6 +1977,7 @@ export const rejectClaim = mutation({
       await ctx.scheduler.runAfter(0, internal.emailSend.sendRequestRejected, {
         claimId: args.claimId,
         borrowerEmail: borrower.email,
+        locale: borrower.profile.locale,
         data: {
           borrowerName: borrower.name,
           itemName: item.name,
@@ -2052,6 +2061,8 @@ export const markExpired = mutation({
         alertType: "expired",
         ownerEmail: owner.email,
         borrowerEmail: borrowerResolved.email,
+        ownerLocale: owner.profile.locale,
+        borrowerLocale: borrowerResolved.profile.locale,
         ownerData: {
           recipientName: owner.name,
           itemName: item.name,
@@ -2153,6 +2164,8 @@ export const markMissing = mutation({
         alertType: "missing",
         ownerEmail: owner.email,
         borrowerEmail: borrowerResolved.email,
+        ownerLocale: owner.profile.locale,
+        borrowerLocale: borrowerResolved.profile.locale,
         ownerData: {
           recipientName: owner.name,
           itemName: item.name,
@@ -2226,6 +2239,7 @@ export const cancelClaim = mutation({
               itemId: claim.itemId,
               recipientClerkId: sub.userId,
               recipientEmail: subscriber.email,
+              locale: subscriber.profile.locale,
               data: {
                 recipientName: subscriber.name,
                 itemName: availableItemName,
@@ -2418,6 +2432,8 @@ export const resolveOverdueProposals = internalMutation({
             alertType: "expired",
             ownerEmail: ownerExp.email,
             borrowerEmail: borrowerExp.email,
+            ownerLocale: ownerExp.profile.locale,
+            borrowerLocale: borrowerExp.profile.locale,
             ownerData: {
               recipientName: ownerExp.name,
               itemName: item.name,
@@ -2487,6 +2503,8 @@ export const resolveOverdueProposals = internalMutation({
             alertType: "missing",
             ownerEmail: ownerMiss.email,
             borrowerEmail: borrowerMiss.email,
+            ownerLocale: ownerMiss.profile.locale,
+            borrowerLocale: borrowerMiss.profile.locale,
             ownerData: {
               recipientName: ownerMiss.name,
               itemName: item.name,


### PR DESCRIPTION
- convex-side dict in emailTemplates/i18n.ts (no next-intl, wrong runtime)
- SharityEmail now requires locale — TS enforces on new templates
- items.ts/http.ts pass user.profile.locale at every scheduler call site