### PR TITLE
feat(my-items): add bandwidth-optimized row thumbnails

### DIFF
--- a/components/cloudinary-image.tsx
+++ b/components/cloudinary-image.tsx
@@ -47,6 +47,18 @@ type CloudinaryImageProps =
       height: number;
     };
 
+export function cloudinaryThumbnailUrl(
+  src: string,
+  size: number = 96,
+): string | null {
+  if (!isCloudinaryImageUrl(src)) return null;
+  const transform = `f_auto,q_auto:eco,c_fill,w_${size},h_${size}`;
+  return src.replace(
+    CLOUDINARY_UPLOAD_SEGMENT,
+    `${CLOUDINARY_UPLOAD_SEGMENT}${transform}/`,
+  );
+}
+
 export function CloudinaryImage(props: CloudinaryImageProps) {
   if (!isCloudinaryImageUrl(props.src)) {
     throw new Error(

--- a/components/management-row.tsx
+++ b/components/management-row.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import Link from "next/link";
 import { useQuery } from "convex/react";
 import { useTranslations } from "next-intl";
@@ -18,8 +19,28 @@ import {
   getDueStatus,
   type OwnerItemStatus,
 } from "@/components/item-status-badge";
+import { cloudinaryThumbnailUrl } from "@/components/cloudinary-image";
 import { ItemEditActions } from "@/components/item-edit-actions";
 import type { MediaImage } from "@/components/item-form";
+
+// --- Shared thumbnail ---
+
+function RowThumbnail({ url, name }: { url: string; name: string }) {
+  const thumbUrl = cloudinaryThumbnailUrl(url);
+  if (!thumbUrl) return null;
+  return (
+    <div className="h-12 w-12 shrink-0 overflow-hidden rounded-md bg-muted">
+      <Image
+        src={thumbUrl}
+        alt={name}
+        width={48}
+        height={48}
+        unoptimized
+        className="h-full w-full object-cover"
+      />
+    </div>
+  );
+}
 
 // --- Owner row ---
 
@@ -72,6 +93,9 @@ function OwnerManagementRow({ item }: { item: OwnerItem }) {
 
   return (
     <div className="rounded-lg border bg-card p-3 shadow-sm flex items-stretch gap-3">
+      {item.imageUrls?.[0] && (
+        <RowThumbnail url={item.imageUrls[0]} name={item.name} />
+      )}
       {/* Left col: dot+title / badges */}
       <div className="flex-1 min-w-0 space-y-1">
         <div className="flex items-center gap-2">
@@ -157,6 +181,9 @@ function BorrowerManagementRow({ item }: { item: BorrowedItem }) {
 
   return (
     <div className="rounded-lg border bg-card p-3 shadow-sm flex items-stretch gap-3">
+      {item.imageUrls?.[0] && (
+        <RowThumbnail url={item.imageUrls[0]} name={item.name} />
+      )}
       {/* Left col: dot+title / badges+owner */}
       <div className="flex-1 min-w-0 space-y-1">
         <div className="flex items-center gap-2">

--- a/components/management-row.tsx
+++ b/components/management-row.tsx
@@ -29,7 +29,7 @@ function RowThumbnail({ url, name }: { url: string; name: string }) {
   const thumbUrl = cloudinaryThumbnailUrl(url);
   if (!thumbUrl) return null;
   return (
-    <div className="h-12 w-12 shrink-0 overflow-hidden rounded-md bg-muted">
+    <div className="h-10 w-10 shrink-0 overflow-hidden rounded-md border bg-muted">
       <Image
         src={thumbUrl}
         alt={name}

--- a/components/wishlist/wishlist-item.tsx
+++ b/components/wishlist/wishlist-item.tsx
@@ -177,7 +177,7 @@ export function WishlistItem({ item, compact }: WishlistItemProps) {
             <button
               type="button"
               onClick={() => setPreviewImage(cloudImages[0].url)}
-              className="relative h-10 w-10 shrink-0 overflow-hidden rounded-md border bg-gray-100 hover:opacity-80 transition-opacity"
+              className="relative h-10 w-10 shrink-0 overflow-hidden rounded-md border bg-muted hover:opacity-80 transition-opacity"
             >
               <CloudinaryImage
                 src={cloudImages[0].url}


### PR DESCRIPTION
- add cloudinaryThumbnailUrl helper (c_fill, w_96, q_auto:eco, no dpr_auto)
- render 48px thumbnail in owner + borrower management rows
- skip next/image optimizer (url pre-transformed by cloudinary)