### PR TITLE
feat(posthog): wire 3 PMF events for sharing loop

### DIFF
--- a/ANALYTICS.md
+++ b/ANALYTICS.md
@@ -1,0 +1,143 @@
+# Analytics — PMF Tracking
+
+Sharity is a two-sided sharing marketplace. PMF signal = **the sharing loop spins on its own**.
+
+```
+Owner lists → Borrower requests → Owner approves → Physical handoff → Return → Repeat
+```
+
+We track 3 events that cover the entire loop. From them we derive 4 metrics that prove (or disprove) PMF.
+
+---
+
+## Tracked Events
+
+All events are captured via PostHog client. Definitions live in [`lib/posthog/events.ts`](lib/posthog/events.ts).
+
+### `item_listed`
+
+Fired when an owner successfully creates a new item.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `item_id` | `string` | Convex item ID |
+| `has_images` | `boolean` | Whether images were uploaded |
+| `mode` | `"lease" \| "giveaway"` | Sharing mode |
+
+**Call site:** [`components/add-item-form.tsx`](components/add-item-form.tsx) — after `createItem` succeeds.
+
+---
+
+### `claim_requested`
+
+Fired when a borrower submits a request for an item.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `item_id` | `string` | Convex item ID |
+| `duration_days` | `number` | Requested borrow duration in days |
+
+**Call sites:** [`hooks/use-claim-item.ts`](hooks/use-claim-item.ts) — after `requestItem` succeeds (both date-picker and intraday paths).
+
+---
+
+### `exchange_completed`
+
+Fired when a pickup is confirmed (item physically handed over).
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `item_id` | `string` | Convex item ID |
+| `claim_id` | `string` | Convex claim ID |
+| `is_giveaway` | `boolean` | True if item is being given away (no return) |
+| `days_since_approval` | `number` | Days between claim approval and pickup |
+
+**Call site:** [`hooks/use-tracked-pickup.ts`](hooks/use-tracked-pickup.ts) — wraps `markPickedUp` mutation. Used in:
+- [`app/[locale]/item/[id]/page.tsx`](app/%5Blocale%5D/item/%5Bid%5D/page.tsx)
+- [`components/lease/borrower-request-panel.tsx`](components/lease/borrower-request-panel.tsx)
+- [`components/notifications/notification-feed.tsx`](components/notifications/notification-feed.tsx)
+
+`isGiveaway` and `approvedAt` are passed from [`components/lease/lease-claim-card.tsx`](components/lease/lease-claim-card.tsx) where the claim context is available.
+
+---
+
+## PMF Metrics
+
+### 1. Successful Exchange Rate
+
+```
+exchange_completed count / claim_requested count (rolling 30d)
+```
+
+Single number spanning the full funnel. High = approval, logistics, and trust all work.
+
+**PostHog:** Funnel insight — `claim_requested` → `exchange_completed`. Group by week.
+
+---
+
+### 2. Supply Activation Rate
+
+```
+unique item_id on claim_requested / unique item_id on item_listed (rolling 30d)
+```
+
+Dead supply = no marketplace. Catches "list and forget" problem.
+
+**PostHog:** Two trend insights (unique property count on `item_id`); divide in the dashboard.
+
+---
+
+### 3. Repeat Usage Rate
+
+```
+users with 2+ exchange_completed / users with 1+ exchange_completed (rolling 30d)
+```
+
+One exchange = curiosity. Two = habit. This IS PMF.
+
+**PostHog:** Lifecycle insight on `exchange_completed`; filter for "returning" users.
+
+---
+
+### 4. Time to First Exchange
+
+```
+median(first exchange_completed timestamp − first $identify timestamp)
+```
+
+Activation speed. Long = churn before value. Short = product clicks.
+
+**PostHog:** User path or custom formula using person's first `$identify` vs first `exchange_completed`.
+
+---
+
+## PostHog Setup
+
+1. Go to **Insights** → **New insight**
+2. Build each metric as described above
+3. Pin all 4 to a **PMF Dashboard**
+4. Set dashboard to refresh weekly
+
+PostHog init is in [`instrumentation-client.ts`](instrumentation-client.ts).
+User identity (Clerk ID + email) is set in [`components/posthog-identify.tsx`](components/posthog-identify.tsx).
+
+---
+
+## Adding New Events
+
+1. Add the event name to the `EVENTS` const in [`lib/posthog/events.ts`](lib/posthog/events.ts) — this is the canonical source of truth for all event name strings. Never inline event name strings in `posthog.capture()` calls.
+2. Add a props type and a `trackXxx` function in the same file, using `EVENTS.YOUR_EVENT` in the `capture` call.
+3. Call `trackXxx(...)` at the mutation success point in the relevant hook or component.
+4. If the tracker needs to wrap a `useMutation`, follow the pattern in [`hooks/use-tracked-pickup.ts`](hooks/use-tracked-pickup.ts): keep the analytics args type local (unexported), and wrap the returned function in `useCallback` so the reference is stable across renders.
+5. Document the new event here.
+
+Keep event names `snake_case`. Properties `snake_case`. No PII beyond what PostHog already captures via identify.
+
+### Key files
+
+| File | Role |
+|------|------|
+| [`lib/posthog/events.ts`](lib/posthog/events.ts) | `EVENTS` const, `ONE_DAY_MS`, typed capture functions |
+| [`hooks/use-tracked-pickup.ts`](hooks/use-tracked-pickup.ts) | Pattern for wrapping a mutation with tracking; `TrackedPickupArgs` is local here, not exported |
+| [`hooks/use-claim-item.ts`](hooks/use-claim-item.ts) | `claim_requested` tracking after `requestItem` |
+| [`components/add-item-form.tsx`](components/add-item-form.tsx) | `item_listed` tracking after `createItem` |

--- a/app/[locale]/item/[id]/page.tsx
+++ b/app/[locale]/item/[id]/page.tsx
@@ -36,6 +36,7 @@ import { ItemCalendar } from "@/components/item-calendar";
 import { isCloudinaryImageUrl } from "@/components/cloudinary-image";
 import { cn } from "@/lib/utils";
 import { useItemCalendar } from "@/hooks/use-item-calendar";
+import { useTrackedPickup } from "@/hooks/use-tracked-pickup";
 import { api } from "@/convex/_generated/api";
 import type { Doc, Id } from "@/convex/_generated/dataModel";
 import { useTranslations } from "next-intl";
@@ -62,7 +63,7 @@ export default function ItemDetailPage({
   const deleteItem = useMutation(api.items.deleteItem);
   const approveClaim = useMutation(api.items.approveClaim);
   const rejectClaim = useMutation(api.items.rejectClaim);
-  const markPickedUp = useMutation(api.items.markPickedUp);
+  const markPickedUp = useTrackedPickup();
   const markReturned = useMutation(api.items.markReturned);
   const markExpired = useMutation(api.items.markExpired);
   const markMissing = useMutation(api.items.markMissing);

--- a/components/add-item-form.tsx
+++ b/components/add-item-form.tsx
@@ -2,6 +2,7 @@
 
 import { useMutation } from "convex/react";
 import { api } from "../convex/_generated/api";
+import { trackItemListed } from "@/lib/posthog/events";
 import { ItemForm } from "./item-form";
 import { Button } from "@/components/ui/button";
 import { SignedIn, SignedOut, SignInButton } from "@clerk/nextjs";
@@ -26,6 +27,11 @@ export function AddItemForm({
         <ItemForm
           onSubmit={async (values) => {
             const itemId = await createItem(values);
+            trackItemListed({
+              item_id: itemId,
+              has_images: (values.imageCloudinary?.length ?? 0) > 0,
+              mode: values.giveaway ? "giveaway" : "lease",
+            });
             onSuccess?.(itemId);
           }}
           submitLabel={t("submit")}

--- a/components/lease/borrower-request-panel.tsx
+++ b/components/lease/borrower-request-panel.tsx
@@ -14,6 +14,7 @@ import {
   type BorrowerCalendarState,
 } from "@/hooks/use-item-calendar";
 import { useClaimItem } from "@/hooks/use-claim-item";
+import { useTrackedPickup } from "@/hooks/use-tracked-pickup";
 import type { Doc } from "@/convex/_generated/dataModel";
 import { api } from "@/convex/_generated/api";
 import { LeaseClaimCard } from "./lease-claim-card";
@@ -272,7 +273,7 @@ export function BorrowerRequestActions() {
   } = useBorrowerRequestContext();
   const t = useTranslations("BorrowerRequest");
 
-  const markPickedUp = useMutation(api.items.markPickedUp);
+  const markPickedUp = useTrackedPickup();
   const markReturned = useMutation(api.items.markReturned);
   const [showInactive, setShowInactive] = React.useState(false);
 
@@ -449,7 +450,7 @@ export function GiveawayBorrowerRequestPanel({
 
   const t = useTranslations("BorrowerRequest");
 
-  const markPickedUp = useMutation(api.items.markPickedUp);
+  const markPickedUp = useTrackedPickup();
   const markReturned = useMutation(api.items.markReturned);
 
   const [pickupDay, setPickupDay] = React.useState<Date | undefined>(undefined);

--- a/components/lease/lease-claim-card.tsx
+++ b/components/lease/lease-claim-card.tsx
@@ -27,6 +27,7 @@ import type {
   MarkLeaseStatusArgs,
   MutationResult,
   RecordLeaseArgs,
+  RecordPickupArgs,
   RejectClaimArgs,
   ViewerRole,
 } from "./lease-claim-types";
@@ -107,7 +108,7 @@ export function LeaseClaimCard(props: {
   approveClaim?: (args: ApproveClaimArgs) => MutationResult;
   rejectClaim?: (args: RejectClaimArgs) => MutationResult;
   cancelClaim?: (args: CancelClaimArgs) => MutationResult;
-  markPickedUp: (args: RecordLeaseArgs) => MutationResult;
+  markPickedUp: (args: RecordPickupArgs) => MutationResult;
   markReturned: (args: RecordLeaseArgs) => MutationResult;
   markExpired?: (args: MarkLeaseStatusArgs) => MutationResult;
   markMissing?: (args: MarkLeaseStatusArgs) => MutationResult;
@@ -597,6 +598,8 @@ export function LeaseClaimCard(props: {
                                 claimId: claim._id,
                                 note,
                                 photoCloudinary,
+                                isGiveaway,
+                                approvedAt: claim.approvedAt,
                               });
                               toast.success(t("pickup.confirmedToast"));
                             } catch (error: unknown) {

--- a/components/lease/lease-claim-types.ts
+++ b/components/lease/lease-claim-types.ts
@@ -15,6 +15,11 @@ export type RecordLeaseArgs = {
   photoCloudinary?: CloudinaryRef[];
 };
 
+export type RecordPickupArgs = RecordLeaseArgs & {
+  isGiveaway?: boolean;
+  approvedAt?: number;
+};
+
 export type MarkLeaseStatusArgs = {
   itemId: Id<"items">;
   claimId: Id<"claims">;

--- a/components/notifications/notification-feed.tsx
+++ b/components/notifications/notification-feed.tsx
@@ -3,6 +3,7 @@
 import { useQuery, useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { Id } from "@/convex/_generated/dataModel";
+import { useTrackedPickup } from "@/hooks/use-tracked-pickup";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { format, formatDistanceToNow } from "date-fns";
@@ -21,7 +22,7 @@ export function NotificationFeed() {
   const rejectClaim = useMutation(api.items.rejectClaim);
   const approvePickupWindow = useMutation(api.items.approvePickupWindow);
   const approveReturnWindow = useMutation(api.items.approveReturnWindow);
-  const markPickedUp = useMutation(api.items.markPickedUp);
+  const markPickedUp = useTrackedPickup();
   const markReturned = useMutation(api.items.markReturned);
   const router = useRouter();
 

--- a/hooks/use-claim-item.ts
+++ b/hooks/use-claim-item.ts
@@ -1,6 +1,7 @@
 import { useQuery, useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { Id } from "@/convex/_generated/dataModel";
+import { trackClaimRequested, ONE_DAY_MS } from "@/lib/posthog/events";
 import { useState } from "react";
 import { toast } from "sonner";
 import { useConvexAuth } from "convex/react";
@@ -52,6 +53,12 @@ export function useClaimItem(itemId: Id<"items">) {
         id: itemId,
         startDate: startDate.getTime(),
         endDate: endDate.getTime(),
+      });
+      trackClaimRequested({
+        item_id: itemId,
+        duration_days: Math.ceil(
+          (endDate.getTime() - startDate.getTime()) / ONE_DAY_MS,
+        ),
       });
       toast.success("Item requested successfully");
       onSuccess?.();
@@ -108,6 +115,10 @@ export function useClaimItem(itemId: Id<"items">) {
         id: itemId,
         startDate: startAt,
         endDate: endAt,
+      });
+      trackClaimRequested({
+        item_id: itemId,
+        duration_days: Math.ceil((endAt - startAt) / ONE_DAY_MS),
       });
       toast.success("Item requested successfully");
       onSuccess?.();

--- a/hooks/use-tracked-pickup.ts
+++ b/hooks/use-tracked-pickup.ts
@@ -1,0 +1,29 @@
+import { useCallback } from "react";
+import { useMutation } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import { trackExchangeCompleted, ONE_DAY_MS } from "@/lib/posthog/events";
+import type { RecordPickupArgs } from "@/components/lease/lease-claim-types";
+
+export function useTrackedPickup(): (
+  args: RecordPickupArgs,
+) => Promise<null | void> {
+  const markPickedUp = useMutation(api.items.markPickedUp);
+
+  return useCallback(
+    async ({ isGiveaway, approvedAt, ...mutationArgs }: RecordPickupArgs) => {
+      const result = await markPickedUp(mutationArgs);
+      const daysSinceApproval =
+        approvedAt != null
+          ? Math.round((Date.now() - approvedAt) / ONE_DAY_MS)
+          : 0;
+      trackExchangeCompleted({
+        item_id: mutationArgs.itemId,
+        claim_id: mutationArgs.claimId,
+        is_giveaway: isGiveaway ?? false,
+        days_since_approval: daysSinceApproval,
+      });
+      return result;
+    },
+    [markPickedUp],
+  );
+}

--- a/lib/posthog/events.ts
+++ b/lib/posthog/events.ts
@@ -1,0 +1,39 @@
+import posthog from "posthog-js";
+
+export const EVENTS = {
+  ITEM_LISTED: "item_listed",
+  CLAIM_REQUESTED: "claim_requested",
+  EXCHANGE_COMPLETED: "exchange_completed",
+} as const;
+
+export const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+type ItemListedProps = {
+  item_id: string;
+  has_images: boolean;
+  mode: "lease" | "giveaway";
+};
+
+type ClaimRequestedProps = {
+  item_id: string;
+  duration_days: number;
+};
+
+type ExchangeCompletedProps = {
+  item_id: string;
+  claim_id: string;
+  is_giveaway: boolean;
+  days_since_approval: number;
+};
+
+export function trackItemListed(props: ItemListedProps): void {
+  posthog.capture(EVENTS.ITEM_LISTED, props);
+}
+
+export function trackClaimRequested(props: ClaimRequestedProps): void {
+  posthog.capture(EVENTS.CLAIM_REQUESTED, props);
+}
+
+export function trackExchangeCompleted(props: ExchangeCompletedProps): void {
+  posthog.capture(EVENTS.EXCHANGE_COMPLETED, props);
+}


### PR DESCRIPTION
- item_listed on create, claim_requested on request, exchange_completed on pickup
- centralize event names in EVENTS const, share ONE_DAY_MS
- add ANALYTICS.md with metrics, properties, and posthog setup